### PR TITLE
fix `test_ARMA` by increasing tolerance

### DIFF
--- a/test/test_misc_noise.py
+++ b/test/test_misc_noise.py
@@ -88,8 +88,8 @@ def test_ARMA():
     # check default parameters (white noise)
     w = pn.ARMA(100)
     assert w.shape == (100,)
-    assert_allclose(np.std(w), 1.0, rtol=0.2)
-    assert_allclose(np.mean(w), 0.0, atol=0.2)
+    assert_allclose(np.std(w), 1.0, atol=0.25)
+    assert_allclose(np.mean(w), 0.0, atol=0.35)
 
     # check float, list and numpy.arrays as input values
     phi_list = [2, [2], np.array([1, 2])]


### PR DESCRIPTION
tolerances are set to match the limits obtained after a MonteCarlo simulation

this should reduce failing test, but still uses statistically meaningful bounds

For some plots, see the corresponding issue which after merging these changes will be resolved #279.