### PR TITLE
Solve problems with test_firuncfilter_mc_uncertainty_comparison.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ jobs:
         type: string
         default: ""
 
-    parallelism: 8
+    parallelism: 16
 
     executor:
       name: venv_tester
@@ -431,7 +431,7 @@ jobs:
         default: ""
       parallelism:
         type: integer
-        default: 8
+        default: 16
 
     parallelism: << parameters.parallelism >>
 
@@ -455,7 +455,7 @@ jobs:
       - store_results
 
   test_conda_py39:
-    parallelism: 8
+    parallelism: 16
 
     executor: conda_tester
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,7 +63,10 @@ def FIRuncFilter_input(
     )
     filter_theta_covariance = draw(
         hst.one_of(
-            hypothesis_covariance_matrix(number_of_rows=filter_length), hst.just(None)
+            hypothesis_covariance_matrix(
+                number_of_rows=filter_length, max_value=np.max(filter_theta)
+            ),
+            hst.just(None),
         )
     )
 
@@ -78,7 +81,9 @@ def FIRuncFilter_input(
         kind = draw(hst.sampled_from(("float", "diag", "corr")))
     if kind == "diag":
         signal_standard_deviation = draw(
-            hypothesis_float_vector(length=signal_length, min_value=0, max_value=1e2)
+            hypothesis_float_vector(
+                length=signal_length, min_value=0, max_value=np.max(signal)
+            )
         )
     elif kind == "corr":
         random_data = draw(
@@ -93,7 +98,9 @@ def FIRuncFilter_input(
         )
         signal_standard_deviation = scaled_acf[len(scaled_acf) // 2 :]
     else:
-        signal_standard_deviation = draw(hypothesis_not_negative_float(max_value=1e2))
+        signal_standard_deviation = draw(
+            hypothesis_not_negative_float(max_value=np.max(signal))
+        )
 
     lowpass_length = draw(
         hst.integers(min_value=min_accepted_by_scipy_linalg_companion, max_value=10)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -64,7 +64,7 @@ def FIRuncFilter_input(
     filter_theta_covariance = draw(
         hst.one_of(
             hypothesis_covariance_matrix(
-                number_of_rows=filter_length, max_value=np.max(filter_theta)
+                number_of_rows=filter_length, max_value=10 * np.max(filter_theta)
             ),
             hst.just(None),
         )
@@ -82,7 +82,7 @@ def FIRuncFilter_input(
     if kind == "diag":
         signal_standard_deviation = draw(
             hypothesis_float_vector(
-                length=signal_length, min_value=0, max_value=np.max(signal)
+                length=signal_length, min_value=0, max_value=10 * np.max(signal)
             )
         )
     elif kind == "corr":
@@ -99,7 +99,7 @@ def FIRuncFilter_input(
         signal_standard_deviation = scaled_acf[len(scaled_acf) // 2 :]
     else:
         signal_standard_deviation = draw(
-            hypothesis_not_negative_float(max_value=np.max(signal))
+            hypothesis_not_negative_float(max_value=10 * np.max(signal))
         )
 
     lowpass_length = draw(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,16 +14,24 @@ from PyDynamic import make_semiposdef
 from PyDynamic.misc.tools import normalize_vector_or_matrix
 from scipy.signal import correlate
 
-# This will check, if the testrun is executed in the ci environment and if so,
-# disables the 'too_slow' health check. See
-# https://hypothesis.readthedocs.io/en/latest/healthchecks.html#hypothesis.HealthCheck
-# for some details.
 
-settings.register_profile(
-    name="ci", suppress_health_check=(HealthCheck.too_slow,), deadline=None
-)
-if os.getenv("CIRCLECI") == "true":
+def _check_for_ci_to_switch_off_performance_related_healthchecks():
+    if _running_in_ci():
+        _register_and_load_hypothesis_profile_for_slow_ci_machines()
+
+
+def _running_in_ci():
+    return os.getenv("CIRCLECI") == "true"
+
+
+def _register_and_load_hypothesis_profile_for_slow_ci_machines():
+    settings.register_profile(
+        name="ci", suppress_health_check=(HealthCheck.too_slow,), deadline=None
+    )
     settings.load_profile("ci")
+
+
+_check_for_ci_to_switch_off_performance_related_healthchecks()
 
 
 def _print_during_test_to_avoid_timeout(capsys):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -54,9 +54,10 @@ def _is_np_array_with_len_greater_zero(array: Any) -> bool:
 def FIRuncFilter_input(
     draw: Callable, exclude_corr_kind: bool = False
 ) -> Dict[str, Any]:
+    min_accepted_by_scipy_linalg_companion = 2
     filter_length = draw(
-        hst.integers(min_value=2, max_value=100)
-    )  # scipy.linalg.companion requires N >= 2
+        hst.integers(min_value=min_accepted_by_scipy_linalg_companion, max_value=100)
+    )
     filter_theta = draw(
         hypothesis_float_vector(length=filter_length, min_value=1e-2, max_value=1e2)
     )
@@ -95,8 +96,8 @@ def FIRuncFilter_input(
         signal_standard_deviation = draw(hypothesis_not_negative_float(max_value=1e2))
 
     lowpass_length = draw(
-        hst.integers(min_value=2, max_value=10)
-    )  # scipy.linalg.companion requires N >= 2
+        hst.integers(min_value=min_accepted_by_scipy_linalg_companion, max_value=10)
+    )
     lowpass = draw(
         hst.one_of(
             (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -527,7 +527,7 @@ def hypothesis_positive_powers_of_two(
     draw: Callable, min_k: Optional[int] = 0, max_k: Optional[int] = None
 ) -> int:
     k = draw(hst.integers(min_value=min_k, max_value=max_k))
-    two_to_the_k = 2 ** k
+    two_to_the_k = 2**k
     return two_to_the_k
 
 
@@ -542,7 +542,7 @@ def corrmatrix() -> Callable:
             raise ValueError("Correlation scalar should be less than one.")
 
         for k in range(1, Nx):
-            corrmat += np.diag(np.ones(Nx - k) * rho ** (phi * k ** nu), k)
+            corrmat += np.diag(np.ones(Nx - k) * rho ** (phi * k**nu), k)
         corrmat += corrmat.T
         corrmat += np.eye(Nx)
 

--- a/test/test_propagate_filter/conftest.py
+++ b/test/test_propagate_filter/conftest.py
@@ -1,13 +1,22 @@
 from typing import Tuple
 
 import numpy as np
-
-# noinspection PyProtectedMember
+import pytest
+from numpy.random import default_rng
 from PyDynamic import shift_uncertainty
 
 
-def random_array(length):
-    return np.random.randn(length)
+@pytest.fixture
+def rng():
+    return default_rng()
+
+
+@pytest.fixture
+def random_standard_normal_array(rng):
+    def _generate_random_array(length):
+        return rng.standard_normal(length)
+
+    return _generate_random_array
 
 
 def _set_irrelevant_ranges_to_zero(

--- a/test/test_propagate_filter/test_firuncfilter_mc_uncertainty_comparison.py
+++ b/test/test_propagate_filter/test_firuncfilter_mc_uncertainty_comparison.py
@@ -22,7 +22,7 @@ def test(fir_unc_filter_input):
     # In this test, we exclude the case of a valid signal with uncertainty given as
     # the right-sided auto-covariance (acf). This is done, because we currently do not
     # ensure, that the random-drawn acf generates a positive-semidefinite
-    # Toeplitz-matrix. Therefore we cannot construct a valid and equivalent input for
+    # Toeplitz-matrix. Therefore, we cannot construct a valid and equivalent input for
     # the Monte-Carlo method in that case.
 
     # Check output for thinkable permutations of input parameters against a Monte Carlo

--- a/test/test_propagate_filter/test_firuncfilter_mc_uncertainty_comparison.py
+++ b/test/test_propagate_filter/test_firuncfilter_mc_uncertainty_comparison.py
@@ -38,10 +38,10 @@ def test(fir_unc_filter_input):
 
     b = fir_unc_filter_input["theta"]
     a = np.ones(1)
-    if isinstance(fir_unc_filter_input["Utheta"], np.ndarray):
+    if fir_unc_filter_input["Utheta"] is None:
+        Uab = np.zeros((len(b), len(b)))
+    else:
         Uab = fir_unc_filter_input["Utheta"]
-    else:  # Utheta == None
-        Uab = np.zeros((len(b), len(b)))  # MC-method cant deal with Utheta = None
 
     blow = fir_unc_filter_input["blow"]
     if isinstance(blow, np.ndarray):

--- a/test/test_propagate_filter/test_firuncfilter_mc_uncertainty_comparison.py
+++ b/test/test_propagate_filter/test_firuncfilter_mc_uncertainty_comparison.py
@@ -15,7 +15,6 @@ from ..conftest import FIRuncFilter_input
         *settings.default.suppress_health_check,
         HealthCheck.too_slow,
     ],
-    max_examples=50,
 )
 @pytest.mark.slow
 def test(fir_unc_filter_input):

--- a/test/test_propagate_filter/test_propagate_filter.py
+++ b/test/test_propagate_filter/test_propagate_filter.py
@@ -44,7 +44,7 @@ def equal_signals(random_standard_normal_array):
     N = np.random.randint(100, 1000)
     signal = random_standard_normal_array(N)
     s = np.random.randn()
-    acf = np.array([s ** 2] + [0] * (N - 1))
+    acf = np.array([s**2] + [0] * (N - 1))
 
     equal_signals = [
         {"y": signal, "sigma_noise": s, "kind": "float"},

--- a/test/test_propagate_filter/test_propagate_filter.py
+++ b/test/test_propagate_filter/test_propagate_filter.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 import scipy
 from numpy.testing import assert_allclose
-
 from PyDynamic.misc.testsignals import rect
 
 # noinspection PyProtectedMember
@@ -16,17 +15,17 @@ from PyDynamic.uncertainty.propagate_filter import (
     IIRuncFilter,
 )
 from PyDynamic.uncertainty.propagate_MonteCarlo import MC
-from .conftest import random_array
+
 from ..conftest import random_covariance_matrix
 
 
 @pytest.fixture
-def equal_filters():
+def equal_filters(random_standard_normal_array):
     # Create two filters with assumed identical FIRuncFilter() output to test
     # equality of the more efficient with the standard implementation.
 
     N = np.random.randint(2, 100)  # scipy.linalg.companion requires N >= 2
-    theta = random_array(N)
+    theta = random_standard_normal_array(N)
 
     equal_filters = [
         {"theta": theta, "Utheta": None},
@@ -37,13 +36,13 @@ def equal_filters():
 
 
 @pytest.fixture
-def equal_signals():
+def equal_signals(random_standard_normal_array):
     # Create three signals with assumed identical FIRuncFilter() output to test
     # equality of the different cases of input parameter 'kind'.
 
     # some shortcuts
     N = np.random.randint(100, 1000)
-    signal = random_array(N)
+    signal = random_standard_normal_array(N)
     s = np.random.randn()
     acf = np.array([s ** 2] + [0] * (N - 1))
 
@@ -77,13 +76,13 @@ def test_FIRuncFilter_equality(equal_filters, equal_signals):
 
 
 @pytest.mark.slow
-def test_fir_filter_MC_comparison():
+def test_fir_filter_MC_comparison(random_standard_normal_array):
     N_signal = np.random.randint(20, 25)
-    x = random_array(N_signal)
+    x = random_standard_normal_array(N_signal)
     Ux = random_covariance_matrix(N_signal)
 
     N_theta = np.random.randint(2, 5)  # scipy.linalg.companion requires N >= 2
-    theta = random_array(N_theta)  # scipy.signal.firwin(N_theta, 0.1)
+    theta = random_standard_normal_array(N_theta)  # scipy.signal.firwin(N_theta, 0.1)
     Utheta = random_covariance_matrix(N_theta)
 
     # run method


### PR DESCRIPTION
Pretty frequently our test of the MonteCarlo to FIRuncFilter comparison fails due to some difference in the compared values bigger than the allowed tolerance. We try to dig deeper into the structure to achieve reliably passing tests for correct inputs.

The fix is actually restricted to lines [66 to 107 in conftest.py](https://github.com/PTB-M4D/PyDynamic/pull/281/files#diff-7dae78a00d8d69422a3bfbde96c7c5d794eede504a0df763853896a1ba1b5ff2R66-R107). The fix is restricting the uncertainties for the filter coefficients and the signal vector to ten times the maximum of the corresponding vector. 10 was chosen arbitrarily here in lack of something more educated.

The other changes are concerned with uplifting pipeline performance, and cleaning some bits and pieces here and there.