### PR TITLE
Update deps

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -37,7 +37,7 @@ cffi==1.15.1
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via
@@ -101,7 +101,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-hypothesis==6.54.3
+hypothesis==6.54.4
     # via -r requirements/dev-requirements.in
 idna==3.3
     # via requests
@@ -136,7 +136,7 @@ jinja2==3.1.2
     #   nbsphinx
     #   notebook
     #   sphinx
-jsonschema==4.12.1
+jsonschema==4.14.0
     # via nbformat
 jupyter-client==7.3.4
     # via
@@ -316,7 +316,7 @@ pyzmq==23.2.1
     #   ipykernel
     #   jupyter-client
     #   notebook
-readme-renderer==36.0
+readme-renderer==37.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in

--- a/requirements/dev-requirements-py37.txt
+++ b/requirements/dev-requirements-py37.txt
@@ -35,7 +35,7 @@ cffi==1.15.1
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via
@@ -97,7 +97,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-hypothesis==6.54.3
+hypothesis==6.54.4
     # via -r requirements/dev-requirements.in
 idna==3.3
     # via requests
@@ -143,7 +143,7 @@ jinja2==3.1.2
     #   nbsphinx
     #   notebook
     #   sphinx
-jsonschema==4.12.1
+jsonschema==4.14.0
     # via nbformat
 jupyter-client==7.3.4
     # via
@@ -323,7 +323,7 @@ pyzmq==23.2.1
     #   ipykernel
     #   jupyter-client
     #   notebook
-readme-renderer==36.0
+readme-renderer==37.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -37,7 +37,7 @@ cffi==1.15.1
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via
@@ -101,7 +101,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-hypothesis==6.54.3
+hypothesis==6.54.4
     # via -r requirements/dev-requirements.in
 idna==3.3
     # via requests
@@ -141,7 +141,7 @@ jinja2==3.1.2
     #   nbsphinx
     #   notebook
     #   sphinx
-jsonschema==4.12.1
+jsonschema==4.14.0
     # via nbformat
 jupyter-client==7.3.4
     # via
@@ -323,7 +323,7 @@ pyzmq==23.2.1
     #   ipykernel
     #   jupyter-client
     #   notebook
-readme-renderer==36.0
+readme-renderer==37.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -37,7 +37,7 @@ cffi==1.15.1
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via
@@ -101,7 +101,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-hypothesis==6.54.3
+hypothesis==6.54.4
     # via -r requirements/dev-requirements.in
 idna==3.3
     # via requests
@@ -139,7 +139,7 @@ jinja2==3.1.2
     #   nbsphinx
     #   notebook
     #   sphinx
-jsonschema==4.12.1
+jsonschema==4.14.0
     # via nbformat
 jupyter-client==7.3.4
     # via
@@ -319,7 +319,7 @@ pyzmq==23.2.1
     #   ipykernel
     #   jupyter-client
     #   notebook
-readme-renderer==36.0
+readme-renderer==37.0
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after the committed deps       were successfully compiled and all tests passed with the       new versions. It should be merged as soon as possible to       avoid any security issues due to outdated dependencies.