### PR TITLE
Fix UMC_generic and add additional functionality

### DIFF
--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -798,11 +798,8 @@ def UMC_generic(
                 for h in happr.values():
                     h["bin-counts"][:, k] += np.histogram(
                         Y[:, k], bins=h["bin-edges"][:, k]
-                    )[
-                        0
-                    ]  # numpy histogram returns (bin-counts, bin-edges)
+                    )[0]
 
-        if return_histograms:
             ymin = np.min(np.vstack((ymin, Y)), axis=0)
             ymax = np.max(np.vstack((ymax, Y)), axis=0)
 

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -743,12 +743,12 @@ def UMC_generic(
 
     for m in range(nblocks):
         if m == nblocks:
-            curr_block = runs % blocksize
+            number_of_samples_in_current_block = runs % blocksize
         else:
-            curr_block = blocksize
+            number_of_samples_in_current_block = blocksize
 
-        Y = np.empty((curr_block, np.prod(output_shape)))
-        samples = draw_samples(curr_block)
+        Y = np.empty((number_of_samples_in_current_block, np.prod(output_shape)))
+        samples = draw_samples(number_of_samples_in_current_block)
 
         # evaluate samples in parallel loop
         for k, result in enumerate(map_func(evaluate, samples)):
@@ -758,13 +758,13 @@ def UMC_generic(
             y = np.mean(Y, axis=0)
 
             if compute_full_covariance:
-                Uy = np.matmul((Y - y).T, (Y - y)) / (curr_block - 1)
+                Uy = np.matmul((Y - y).T, (Y - y)) / (number_of_samples_in_current_block - 1)
             else:
-                Uy = np.sum(np.square(Y - y), axis=0) / (curr_block - 1)
+                Uy = np.sum(np.square(Y - y), axis=0) / (number_of_samples_in_current_block - 1)
 
         else:  # updating y and Uy from results of current block
             K0 = m * blocksize
-            K_seq = curr_block
+            K_seq = number_of_samples_in_current_block
 
             # update mean (formula 7 in [Eichst2012])
             y0 = y
@@ -801,7 +801,7 @@ def UMC_generic(
         # save results if wanted
         if return_samples:
             block_start = m * blocksize
-            block_end = block_start + curr_block
+            block_end = block_start + number_of_samples_in_current_block
             sims["samples"][block_start:block_end] = samples
             sims["results"][block_start:block_end] = np.asarray(
                 [element.reshape(output_shape) for element in Y]

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -606,10 +606,10 @@ def UMC_generic(
     blocksize=8,
     runs_init=10,
     nbins=100,
-    return_histograms=True,
     return_samples=False,
-    compute_full_covariance=True,
     n_cpu=multiprocessing.cpu_count(),
+    return_histograms=True,
+    compute_full_covariance=True,
 ):
     """
     Generic Batch Monte Carlo using update formulae for mean, variance and (approximated) histogram.
@@ -632,14 +632,14 @@ def UMC_generic(
             how many samples to evaluate to form initial guess about limits
         nbins: int, list of int, optional
             number of bins for histogram
-        return_histograms: bool, optional
-            whether to compute a histogram for each entry of the result at all
         return_samples: bool, optional
             see return-value of documentation
-        compute_full_covariance: bool, optional
-            whether to compute the full covariance matrix or just its diagonal
         n_cpu: int, optional
             number of CPUs to use for multiprocessing, defaults to all available CPUs
+        return_histograms: bool, optional
+            whether to compute a histogram for each entry of the result at all
+        compute_full_covariance: bool, optional
+            whether to compute the full covariance matrix or just its diagonal
 
     Example
     -------

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -742,7 +742,7 @@ def UMC_generic(
         }
 
     for m in range(nblocks):
-        if m == nblocks:
+        if m == nblocks - 1:
             number_of_samples_in_current_block = runs % blocksize
         else:
             number_of_samples_in_current_block = blocksize

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -743,7 +743,10 @@ def UMC_generic(
 
     for m in range(nblocks):
         if m == nblocks - 1:
-            number_of_samples_in_current_block = runs % blocksize
+            if runs % blocksize == 0:
+                number_of_samples_in_current_block = blocksize
+            else:
+                number_of_samples_in_current_block = runs % blocksize
         else:
             number_of_samples_in_current_block = blocksize
 

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -814,7 +814,7 @@ def UMC_generic(
 
     # ----------------- post-calculation steps -----------------------
 
-    if return_historgams:
+    if return_histograms:
         # replace edge limits by ymin and ymax, resp.
         for h in happr.values():
             h["bin-edges"][0, :] = np.min(

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -716,11 +716,11 @@ def UMC_generic(
     Y_init = np.asarray(Y_init)
 
     # prepare histograms
-    ymin = np.min(Y_init, axis=0).ravel()
-    ymax = np.max(Y_init, axis=0).ravel()
-
     happr = {}
     if return_histograms:
+        ymin = np.min(Y_init, axis=0).ravel()
+        ymax = np.max(Y_init, axis=0).ravel()
+
         for nbin in nbins:
             happr[nbin] = {}
             happr[nbin]["bin-edges"] = np.linspace(
@@ -795,8 +795,9 @@ def UMC_generic(
                         0
                     ]  # numpy histogram returns (bin-counts, bin-edges)
 
-        ymin = np.min(np.vstack((ymin, Y)), axis=0)
-        ymax = np.max(np.vstack((ymax, Y)), axis=0)
+        if return_histograms:
+            ymin = np.min(np.vstack((ymin, Y)), axis=0)
+            ymax = np.max(np.vstack((ymax, Y)), axis=0)
 
         # save results if wanted
         if return_samples:

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -758,9 +758,13 @@ def UMC_generic(
             y = np.mean(Y, axis=0)
 
             if compute_full_covariance:
-                Uy = np.matmul((Y - y).T, (Y - y)) / (number_of_samples_in_current_block - 1)
+                Uy = np.matmul((Y - y).T, (Y - y)) / (
+                    number_of_samples_in_current_block - 1
+                )
             else:
-                Uy = np.sum(np.square(Y - y), axis=0) / (number_of_samples_in_current_block - 1)
+                Uy = np.sum(np.square(Y - y), axis=0) / (
+                    number_of_samples_in_current_block - 1
+                )
 
         else:  # updating y and Uy from results of current block
             K0 = m * blocksize

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -749,7 +749,7 @@ def UMC_generic(
 
         if m == 0:  # first block
             y = np.mean(Y, axis=0)
-            Uy = np.matmul((Y - y).T, (Y - y))
+            Uy = np.matmul((Y - y).T, (Y - y)) / curr_block
 
         else:  # updating y and Uy from results of current block
             K0 = m * blocksize

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -720,7 +720,7 @@ def UMC_generic(
     ymax = np.max(Y_init, axis=0).ravel()
 
     happr = {}
-    if return_historgams:
+    if return_histograms:
         for nbin in nbins:
             happr[nbin] = {}
             happr[nbin]["bin-edges"] = np.linspace(

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -758,9 +758,9 @@ def UMC_generic(
             y = np.mean(Y, axis=0)
 
             if compute_full_covariance:
-                Uy = np.matmul((Y - y).T, (Y - y)) / curr_block
+                Uy = np.matmul((Y - y).T, (Y - y)) / (curr_block - 1)
             else:
-                Uy = np.mean(np.square(Y - y), axis=0)
+                Uy = np.sum(np.square(Y - y), axis=0) / (curr_block - 1)
 
         else:  # updating y and Uy from results of current block
             K0 = m * blocksize

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -785,7 +785,7 @@ def UMC_generic(
                     + np.sum(np.square(Y - y), axis=0)
                 ) / (K0 + K_seq - 1)
 
-        if return_historgams:
+        if return_histograms:
             # update histogram values
             for k in range(np.prod(output_shape)):
                 for h in happr.values():

--- a/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
+++ b/src/PyDynamic/uncertainty/propagate_MonteCarlo.py
@@ -606,7 +606,7 @@ def UMC_generic(
     blocksize=8,
     runs_init=10,
     nbins=100,
-    return_historgams=True,
+    return_histograms=True,
     return_samples=False,
     compute_full_covariance=True,
     n_cpu=multiprocessing.cpu_count(),

--- a/test/test_propagate_MonteCarlo.py
+++ b/test/test_propagate_MonteCarlo.py
@@ -51,9 +51,9 @@ evaluate_sample = functools.partial(np.mean, axis=1)
 UMC_generic_multiprocess_kwargs = {
     "draw_samples": draw_samples,
     "evaluate": evaluate_sample,
-    "runs": 100,
-    "blocksize": 20,
-    "runs_init": 10,
+    "runs": 10,
+    "blocksize": 3,
+    "runs_init": 3,
 }
 
 UMC_generic_cov_kwargs = {

--- a/test/test_propagate_MonteCarlo.py
+++ b/test/test_propagate_MonteCarlo.py
@@ -178,7 +178,9 @@ def test_UMC_generic_check_sample_shape():
 
 def test_UMC_generic_cov_diag():
     # evaluate only diag covariance + return samples (to check against)
-    y, Uy, _, _, sims = UMC_generic(**UMC_generic_cov_kwargs, compute_full_covariance=False)
+    y, Uy, _, _, sims = UMC_generic(
+        **UMC_generic_cov_kwargs, compute_full_covariance=False
+    )
 
     assert y.size == Uy.shape[0]
     assert Uy.shape == (y.size,)
@@ -194,7 +196,9 @@ def test_UMC_generic_cov_diag():
 
 def test_UMC_generic_cov_full():
     # evaluate only diag covariance + return samples (to check against)
-    y, Uy, _, _, sims = UMC_generic(**UMC_generic_cov_kwargs, compute_full_covariance=True)
+    y, Uy, _, _, sims = UMC_generic(
+        **UMC_generic_cov_kwargs, compute_full_covariance=True
+    )
 
     assert y.size == Uy.shape[0]
     assert Uy.shape == (y.size, y.size)

--- a/test/test_propagate_MonteCarlo.py
+++ b/test/test_propagate_MonteCarlo.py
@@ -123,7 +123,15 @@ def test_SMC():
 def test_UMC(visualizeOutput=False):
     # run method
     y, Uy, p025, p975, happr = UMC(
-        x, b1, [1.0], Ub, blow=b2, sigma=sigma_noise, runs=runs, runs_init=10, nbins=10
+        x,
+        b1,
+        np.ones(1),
+        Ub,
+        blow=b2,
+        sigma=sigma_noise,
+        runs=runs,
+        runs_init=10,
+        nbins=10,
     )
 
     assert len(y) == len(x)
@@ -234,7 +242,7 @@ def test_compare_MC_UMC():
 
     y_MC, Uy_MC = MC(x, sigma_noise, b1, np.ones(1), Ub, runs=2 * runs, blow=b2)
     y_UMC, Uy_UMC, _, _, _ = UMC(
-        x, b1, [1.0], Ub, blow=b2, sigma=sigma_noise, runs=2 * runs, runs_init=10
+        x, b1, np.ones(1), Ub, blow=b2, sigma=sigma_noise, runs=2 * runs, runs_init=10
     )
 
     # both methods should yield roughly the same results

--- a/test/test_propagate_MonteCarlo.py
+++ b/test/test_propagate_MonteCarlo.py
@@ -230,7 +230,6 @@ def test_UMC_generic_cov_full(umc_generic_cov_kwargs):
 
 @pytest.mark.slow
 def test_compare_MC_UMC():
-
     np.random.seed(12345)
 
     y_MC, Uy_MC = MC(x, sigma_noise, b1, np.ones(1), Ub, runs=2 * runs, blow=b2)

--- a/test/test_propagate_MonteCarlo.py
+++ b/test/test_propagate_MonteCarlo.py
@@ -176,14 +176,16 @@ def test_UMC_generic_cov_diag():
         runs_init=2,
         return_histograms=False,
         compute_full_covariance=False,
-        return_samples=True
+        return_samples=True,
     )
 
     assert y.size == Uy.shape[0]
-    assert Uy.shape == (y.size, )
+    assert Uy.shape == (y.size,)
 
     y_sims = np.mean(sims["results"], axis=0).flatten()
-    Uy_sims = np.diag(np.cov(sims["results"].reshape((sims["results"].shape[0], -1)), rowvar=False))
+    Uy_sims = np.diag(
+        np.cov(sims["results"].reshape((sims["results"].shape[0], -1)), rowvar=False)
+    )
 
     assert_allclose(y, y_sims)
     assert_allclose(Uy, Uy_sims)
@@ -203,14 +205,16 @@ def test_UMC_generic_cov_full():
         runs_init=2,
         return_histograms=False,
         compute_full_covariance=True,
-        return_samples=True
+        return_samples=True,
     )
 
     assert y.size == Uy.shape[0]
     assert Uy.shape == (y.size, y.size)
 
     y_sims = np.mean(sims["results"], axis=0).flatten()
-    Uy_sims = np.cov(sims["results"].reshape((sims["results"].shape[0], -1)), rowvar=False)
+    Uy_sims = np.cov(
+        sims["results"].reshape((sims["results"].shape[0], -1)), rowvar=False
+    )
 
     assert_allclose(y, y_sims)
     assert_allclose(Uy, Uy_sims)

--- a/test/test_propagate_MonteCarlo.py
+++ b/test/test_propagate_MonteCarlo.py
@@ -151,6 +151,8 @@ def test_UMC_generic_multiprocessing():
     assert isinstance(happr, dict)
     assert output_shape == (sample_shape[0], sample_shape[2])
 
+
+def test_UMC_generic_no_multiprocessing():
     # run without parallel computation
     y, Uy, happr, output_shape = UMC_generic(**UMC_generic_multiprocess_kwargs, n_cpu=1)
     assert y.size == Uy.shape[0]
@@ -158,6 +160,8 @@ def test_UMC_generic_multiprocessing():
     assert isinstance(happr, dict)
     assert output_shape == (sample_shape[0], sample_shape[2])
 
+
+def test_UMC_generic_check_sample_shape():
     # run again, but only return all simulations
     y, Uy, happr, output_shape, sims = UMC_generic(
         **UMC_generic_multiprocess_kwargs, return_samples=True

--- a/test/test_propagate_MonteCarlo.py
+++ b/test/test_propagate_MonteCarlo.py
@@ -173,6 +173,7 @@ def test_UMC_generic_check_sample_shape():
     assert isinstance(sims, dict)
     assert sims["samples"][0].shape == sample_shape
     assert sims["results"][0].shape == output_shape
+    assert len(sims["samples"]) == UMC_generic_multiprocess_kwargs["runs"]
 
 
 def test_UMC_generic_cov_diag():


### PR DESCRIPTION
This PR fixes #305 and also adds new functionality to the `UMC_generic` method. 

`UMC_generic` can now:

- be executed without generating histograms for each entry in the output y
- be configured to only compute the main diagonal of the covariance matrix

Both options reduce the computational/memory requirements at the cost of . These options are useful for long output vectors (tested up to 1.5e6 entries), where the covariance matrix (likely) doesn't fit into memory any more. (E.g., for 1.5e6 entries, the covariance would need 16TiB, whereas the main diagonal only requires 12MiB. (64bit floats) )