### PR TITLE
Feature: GUM_iDFT support for odd output signals, as well as over- and undersampling

### DIFF
--- a/src/PyDynamic/misc/tools.py
+++ b/src/PyDynamic/misc/tools.py
@@ -139,7 +139,7 @@ def trimOrPad(
 ):
     """Trim or pad (with zeros) a vector/array to the desired length(s)
 
-    Either trim or zero-pad each axis of an array to achieve a specified `length`. 
+    Either trim or zero-pad each axis of an array to achieve a specified `length`.
     The trimming/padding is applied at the end of (each axis of) the array.
     The implementation allows for some axis to be trimmed, while others can be padded
     at the same time.

--- a/src/PyDynamic/misc/tools.py
+++ b/src/PyDynamic/misc/tools.py
@@ -161,7 +161,10 @@ def trimOrPad(
 
 
 def trimOrPad_ND(
-    array: Union[List, np.ndarray], length: Union[int, tuple], mode: Optional[str] = "constant", real_imag_type=False
+    array: Union[List, np.ndarray],
+    length: Union[int, tuple],
+    mode: Optional[str] = "constant",
+    real_imag_type=False,
 ):
     """Trim or pad (with zeros) a vector/array to the desired length(s)
 
@@ -189,31 +192,33 @@ def trimOrPad_ND(
     # force numpy array
     array = np.array(array)
 
-    # split and reassemble if vector/covariance is in real-imag representation 
+    # split and reassemble if vector/covariance is in real-imag representation
     # (only works for 1D and 2D-square arrays of even length)
     if real_imag_type:
         N = array.shape[0] // 2
         kwargs = {
-            "length" : length, 
-            "mode" : "constant", 
-            "real_imag_type" : False,
+            "length": length,
+            "mode": "constant",
+            "real_imag_type": False,
         }
 
         if len(array.shape) == 1:
             R = trimOrPad_ND(array[:N], **kwargs)
             I = trimOrPad_ND(array[N:], **kwargs)
             return np.r_[R, I]
-        
-        elif is_2d_square_matrix(array):
-            RR = trimOrPad_ND(array[:N,:N], **kwargs)
-            RI = trimOrPad_ND(array[:N,N:], **kwargs)
-            IR = trimOrPad_ND(array[N:,:N], **kwargs)
-            II = trimOrPad_ND(array[N:,N:], **kwargs)
 
-            return np.block([[RR, RI],[IR, II]])
+        elif is_2d_square_matrix(array):
+            RR = trimOrPad_ND(array[:N, :N], **kwargs)
+            RI = trimOrPad_ND(array[:N, N:], **kwargs)
+            IR = trimOrPad_ND(array[N:, :N], **kwargs)
+            II = trimOrPad_ND(array[N:, N:], **kwargs)
+
+            return np.block([[RR, RI], [IR, II]])
 
         else:
-            raise ValueError(f"Array of shape {array.shape} cannot be interpreted as real/imag representation.")
+            raise ValueError(
+                f"Array of shape {array.shape} cannot be interpreted as real/imag representation."
+            )
 
     # just trim/pad at the end otherwise
     else:
@@ -224,18 +229,18 @@ def trimOrPad_ND(
         # prepare padding and trimming arguments
         pad_lengths = []
         trim_slices = []
-        for i, (axis_length, axis_new_length) in enumerate(zip(array.shape, length)): 
+        for axis_length, axis_new_length in zip(array.shape, length):
             diff = axis_new_length - axis_length
 
             # prepare padding
             if diff > 0:
                 pad_lengths.append((0, diff))
             else:
-                pad_lengths.append((0,0))
+                pad_lengths.append((0, 0))
 
             # prepare trimming
-            trim_slices.append(slice(0,axis_new_length))
-        
+            trim_slices.append(slice(0, axis_new_length))
+
         # first pad, what needs to be padded
         # then trim (does nothing, if all axis have been padded)
         return np.pad(array, pad_lengths, mode=mode)[tuple(trim_slices)]

--- a/src/PyDynamic/misc/tools.py
+++ b/src/PyDynamic/misc/tools.py
@@ -160,6 +160,87 @@ def trimOrPad(
         return array[0:length]
 
 
+def trimOrPad_ND(
+    array: Union[List, np.ndarray], length: Union[int, tuple], mode: Optional[str] = "constant", real_imag_type=False
+):
+    """Trim or pad (with zeros) a vector/array to the desired length(s)
+
+    Either trim or zero-pad an array to achieve the required `length`. Both actions
+    are applied to the end of (each axis of) the array.
+
+    Parameters
+    ----------
+    array : list, ND np.ndarray
+        original data
+    length : int, tuple of int
+        length of output
+    mode : str, optional
+        handed over to np.pad, default "constant"
+    real_imag_type : bool
+        if array is to be interpreted as PyDynamic real-imag-type
+        only works for 1D and square-2D arrays
+
+    Returns
+    -------
+    array_modified : np.ndarray of shape (length,)
+        An either trimmed or zero-padded array
+    """
+
+    # force numpy array
+    array = np.array(array)
+
+    # split and reassemble if vector/covariance is in real-imag representation 
+    # (only works for 1D and 2D-square arrays of even length)
+    if real_imag_type:
+        N = array.shape[0] // 2
+        kwargs = {
+            "length" : length, 
+            "mode" : "constant", 
+            "real_imag_type" : False,
+        }
+
+        if len(array.shape) == 1:
+            R = trimOrPad_ND(array[:N], **kwargs)
+            I = trimOrPad_ND(array[N:], **kwargs)
+            return np.r_[R, I]
+        
+        elif is_2d_square_matrix(array):
+            RR = trimOrPad_ND(array[:N,:N], **kwargs)
+            RI = trimOrPad_ND(array[:N,N:], **kwargs)
+            IR = trimOrPad_ND(array[N:,:N], **kwargs)
+            II = trimOrPad_ND(array[N:,N:], **kwargs)
+
+            return np.block([[RR, RI],[IR, II]])
+
+        else:
+            raise ValueError(f"Array of shape {array.shape} cannot be interpreted as real/imag representation.")
+
+    # just trim/pad at the end otherwise
+    else:
+        # convert uniform length on all axis into internal tuple representation
+        if isinstance(length, int):
+            length = [length] * len(array.shape)
+
+        # prepare padding and trimming arguments
+        pad_lengths = []
+        trim_slices = []
+        for i, (axis_length, axis_new_length) in enumerate(zip(array.shape, length)): 
+            diff = axis_new_length - axis_length
+
+            # prepare padding
+            if diff > 0:
+                pad_lengths.append((0, diff))
+            else:
+                pad_lengths.append((0,0))
+
+            # prepare trimming
+            trim_slices.append(slice(0,axis_new_length))
+        
+        # first pad, what needs to be padded
+        # then trim (does nothing, if all axis have been padded)
+        return np.pad(array, pad_lengths, mode=mode)[tuple(trim_slices)]
+
+
 def print_vec(vector, prec=5, retS=False, vertical=False):
     """Print vector (1D array) to the console or return as formatted string
 

--- a/src/PyDynamic/misc/tools.py
+++ b/src/PyDynamic/misc/tools.py
@@ -131,9 +131,7 @@ def _shift_2d_matrix(matrix: np.ndarray, shift: int) -> np.ndarray:
     return np.roll(matrix, (shift, shift), axis=(0, 1))
 
 
-def trimOrPad(
-    array: Union[List, np.ndarray], length: int, mode: Optional[str] = "constant"
-):
+def trimOrPad(array: Union[List, np.ndarray], length: int, mode: str = "constant"):
     """Trim or pad (with zeros) a vector to the desired length
 
     Either trim or zero-pad an array to achieve the required `length`. Both actions
@@ -179,8 +177,8 @@ def trimOrPad_ND(
         length of output
     mode : str, optional
         handed over to np.pad, default "constant"
-    real_imag_type : bool
-        if array is to be interpreted as PyDynamic real-imag-type
+    real_imag_type : bool, optional
+        if array is to be interpreted as PyDynamic real-imag-type, defaults to False
         only works for 1D and square-2D arrays
 
     Returns

--- a/src/PyDynamic/misc/tools.py
+++ b/src/PyDynamic/misc/tools.py
@@ -203,9 +203,9 @@ def trimOrPad_ND(
         }
 
         if len(array.shape) == 1:
-            R = trimOrPad_ND(array[:N], **kwargs)
-            I = trimOrPad_ND(array[N:], **kwargs)
-            return np.r_[R, I]
+            REAL = trimOrPad_ND(array[:N], **kwargs)
+            IMAG = trimOrPad_ND(array[N:], **kwargs)
+            return np.r_[REAL, IMAG]
 
         elif is_2d_square_matrix(array):
             RR = trimOrPad_ND(array[:N, :N], **kwargs)

--- a/src/PyDynamic/misc/tools.py
+++ b/src/PyDynamic/misc/tools.py
@@ -161,7 +161,7 @@ def trimOrPad(array: Union[List, np.ndarray], length: int, mode: str = "constant
 def trimOrPad_ND(
     array: Union[List, np.ndarray],
     length: Union[int, tuple],
-    mode: Optional[str] = "constant",
+    mode: str = "constant",
     real_imag_type=False,
 ):
     """Trim or pad (with zeros) a vector/array to the desired length(s)

--- a/src/PyDynamic/misc/tools.py
+++ b/src/PyDynamic/misc/tools.py
@@ -162,7 +162,7 @@ def trimOrPad_ND(
     array: Union[List, np.ndarray],
     length: Union[int, tuple],
     mode: str = "constant",
-    real_imag_type=False,
+    real_imag_type: bool = False,
 ):
     """Trim or pad (with zeros) a vector/array to the desired length(s)
 

--- a/src/PyDynamic/uncertainty/propagate_DFT.py
+++ b/src/PyDynamic/uncertainty/propagate_DFT.py
@@ -57,7 +57,6 @@ from ..misc.tools import (
     is_2d_matrix,
     is_vector,
     number_of_rows_equals_vector_dim,
-    trimOrPad_ND,
 )
 
 

--- a/src/PyDynamic/uncertainty/propagate_DFT.py
+++ b/src/PyDynamic/uncertainty/propagate_DFT.py
@@ -388,10 +388,8 @@ def GUM_iDFT(
     N_in = F.size // 2
 
     # default output length, assumes even output length
-    N_out = Nx
     N_out_default = UF.shape[0] - 2
-    if Nx is None:
-        N_out = N_out_default
+    N_out = N_out_default if Nx is None else Nx
 
     # calculate discrete angular frequency
     beta = 2 * np.pi * np.arange(N_out) / N_out

--- a/src/PyDynamic/uncertainty/propagate_DFT.py
+++ b/src/PyDynamic/uncertainty/propagate_DFT.py
@@ -400,15 +400,15 @@ def GUM_iDFT(
     # propagate uncertainty
     if not isinstance(Cc, np.ndarray) or not isinstance(Cs, np.ndarray):
         k = np.arange(N_in)
-        bk = np.outer(beta, k)
+        k_beta = np.outer(beta, k)
 
     # calculate sensitivities (scaling factor 1/N_out is accounted for at the end)
     if not isinstance(Cc, np.ndarray):
-        Cc = np.cos(bk)
+        Cc = np.cos(k_beta)
         Cc = _adjust_sensitivity_matrix_to_match_irfft(Cc, N_out, N_out_default)
 
     if not isinstance(Cs, np.ndarray):
-        Cs = -np.sin(bk)
+        Cs = -np.sin(k_beta)
         Cs = _adjust_sensitivity_matrix_to_match_irfft(Cs, N_out, N_out_default)
 
     # calculate blocks of uncertainty matrix

--- a/src/PyDynamic/uncertainty/propagate_DFT.py
+++ b/src/PyDynamic/uncertainty/propagate_DFT.py
@@ -436,18 +436,18 @@ def _adjust_sensitivity_matrix_to_match_irfft(C, N_out, N_out_default):
     C[:, 1:] *= 2
 
     # in case of undersampling, remove higher frequencies
-    highest_non_zero_entry = -1
+    highest_non_zero_idx = -1
     if N_out < N_out_default:
 
-        # N_out corresponds only to the first l items of spectrum
-        highest_non_zero_entry = N_out // 2
+        # N_out corresponds only to the first highest_non_zero_idx items of spectrum
+        highest_non_zero_idx = N_out // 2
 
-        # erase influence of spectrum above highest_non_zero_entry
-        C[:, highest_non_zero_entry + 1 :] = 0
+        # erase influence of spectrum above highest_non_zero_idx
+        C[:, highest_non_zero_idx + 1 :] = 0
 
     # undo factor two for even signal lengths
     if N_out % 2 == 0 and N_out <= N_out_default:
-        C[:, highest_non_zero_entry] *= 0.5
+        C[:, highest_non_zero_idx] *= 0.5
 
     return C
 

--- a/src/PyDynamic/uncertainty/propagate_DFT.py
+++ b/src/PyDynamic/uncertainty/propagate_DFT.py
@@ -405,11 +405,11 @@ def GUM_iDFT(
     # calculate sensitivities (scaling factor 1/N_out is accounted for at the end)
     if not isinstance(Cc, np.ndarray):
         Cc = np.cos(bk)
-        Cc = _adjust_sensitivity_matrix_iDFT(Cc, N_out, N_out_default)
+        Cc = _adjust_sensitivity_matrix_to_match_irfft(Cc, N_out, N_out_default)
 
     if not isinstance(Cs, np.ndarray):
         Cs = -np.sin(bk)
-        Cs = _adjust_sensitivity_matrix_iDFT(Cs, N_out, N_out_default)
+        Cs = _adjust_sensitivity_matrix_to_match_irfft(Cs, N_out, N_out_default)
 
     # calculate blocks of uncertainty matrix
     if len(UF.shape) == 2:
@@ -431,7 +431,7 @@ def GUM_iDFT(
         return x, Ux / N_out**2
 
 
-def _adjust_sensitivity_matrix_iDFT(C, N_out, N_out_default):
+def _adjust_sensitivity_matrix_to_match_irfft(C, N_out, N_out_default):
     # multiply by two because to compensate missing left side of spectrum
     C[:, 1:] *= 2
 

--- a/src/PyDynamic/uncertainty/propagate_DFT.py
+++ b/src/PyDynamic/uncertainty/propagate_DFT.py
@@ -329,27 +329,6 @@ def _compute_sensitivity_matrix_wrt_sine_part(_k, _beta):
     return -np.sin(_k * _beta)[np.newaxis, :]
 
 
-def _adjust_sensitivity_matrix_iDFT(C, N_out, N_out_default):
-    # multiply by two because to compensate missing left side of spectrum
-    C[:, 1:] *= 2
-
-    # in case of undersampling, remove higher frequencies
-    highest_non_zero_entry = -1
-    if N_out < N_out_default:
-
-        # N_out corresponds only to the first l items of spectrum
-        highest_non_zero_entry = N_out // 2
-
-        # erase influence of spectrum above highest_non_zero_entry
-        C[:, highest_non_zero_entry + 1 :] = 0
-
-    # undo factor two for even signal lengths
-    if N_out % 2 == 0 and N_out <= N_out_default:
-        C[:, highest_non_zero_entry] *= 0.5
-
-    return C
-
-
 def GUM_iDFT(
     F: np.ndarray,
     UF: np.ndarray,
@@ -452,6 +431,27 @@ def GUM_iDFT(
         return x, Ux / N_out**2, {"Cc": Cc, "Cs": Cs}
     else:
         return x, Ux / N_out**2
+
+
+def _adjust_sensitivity_matrix_iDFT(C, N_out, N_out_default):
+    # multiply by two because to compensate missing left side of spectrum
+    C[:, 1:] *= 2
+
+    # in case of undersampling, remove higher frequencies
+    highest_non_zero_entry = -1
+    if N_out < N_out_default:
+
+        # N_out corresponds only to the first l items of spectrum
+        highest_non_zero_entry = N_out // 2
+
+        # erase influence of spectrum above highest_non_zero_entry
+        C[:, highest_non_zero_entry + 1 :] = 0
+
+    # undo factor two for even signal lengths
+    if N_out % 2 == 0 and N_out <= N_out_default:
+        C[:, highest_non_zero_entry] *= 0.5
+
+    return C
 
 
 def GUM_DFTfreq(N, dt=1):

--- a/test/test_DFT.py
+++ b/test/test_DFT.py
@@ -167,58 +167,59 @@ def DFT_identity_input_output_lengths(draw: Callable):
     return {"input_length": input_length, "output_length": output_length}
 
 
-class TestDFT:
-    def test_DFT_iDFT(self, multisine_testsignal):
-        """Test GUM_DFT and GUM_iDFT with noise variance as uncertainty"""
-        x, ux = multisine_testsignal
-        X, UX = GUM_DFT(x, ux**2)
-        xh, uxh = GUM_iDFT(X, UX)
-        assert_almost_equal(np.max(np.abs(x - xh)), 0)
-        assert_almost_equal(np.max(ux - np.sqrt(np.diag(uxh))), 0)
+def test_DFT_iDFT(multisine_testsignal):
+    """Test GUM_DFT and GUM_iDFT with noise variance as uncertainty"""
+    x, ux = multisine_testsignal
+    X, UX = GUM_DFT(x, ux**2)
+    xh, uxh = GUM_iDFT(X, UX)
+    assert_almost_equal(np.max(np.abs(x - xh)), 0)
+    assert_almost_equal(np.max(ux - np.sqrt(np.diag(uxh))), 0)
 
-    def test_DFT_iDFT_vector(self, multisine_testsignal):
-        """Test GUM_DFT and GUM_iDFT with uncertainty vector"""
-        x, ux = multisine_testsignal
-        ux = (0.1 * x) ** 2
-        X, UX = GUM_DFT(x, ux)
-        xh, uxh = GUM_iDFT(X, UX)
-        assert_almost_equal(np.max(np.abs(x - xh)), 0)
-        assert_almost_equal(np.max(np.sqrt(ux) - np.sqrt(np.diag(uxh))), 0)
 
-    def test_AmpPhasePropagation(self, multisine_testsignal):
-        """Test Time2AmpPhase and AmpPhase2Time with noise variance as uncertainty"""
-        testsignal, noise_std = multisine_testsignal
-        A, P, UAP = Time2AmpPhase(testsignal, noise_std**2)
-        x, ux = AmpPhase2Time(A, P, UAP)
-        assert_almost_equal(np.max(np.abs(testsignal - x)), 0)
+def test_DFT_iDFT_vector(multisine_testsignal):
+    """Test GUM_DFT and GUM_iDFT with uncertainty vector"""
+    x, ux = multisine_testsignal
+    ux = (0.1 * x) ** 2
+    X, UX = GUM_DFT(x, ux)
+    xh, uxh = GUM_iDFT(X, UX)
+    assert_almost_equal(np.max(np.abs(x - xh)), 0)
+    assert_almost_equal(np.max(np.sqrt(ux) - np.sqrt(np.diag(uxh))), 0)
 
-    # @given(DFT_identity_input_output_lengths())
-    @pytest.mark.parametrize("N", [9, 10, 11, 12, 15, 20])
-    @pytest.mark.parametrize("Nx", [9, 10, 11, 12, 15, 20])
-    def test_DFT_identity(self, N, Nx):
 
-        x, x_cov = np.arange(N) + 2, np.eye(N)
+def test_AmpPhasePropagation(multisine_testsignal):
+    """Test Time2AmpPhase and AmpPhase2Time with noise variance as uncertainty"""
+    testsignal, noise_std = multisine_testsignal
+    A, P, UAP = Time2AmpPhase(testsignal, noise_std**2)
+    x, ux = AmpPhase2Time(A, P, UAP)
+    assert_almost_equal(np.max(np.abs(testsignal - x)), 0)
 
-        # get spectrum
-        X, X_cov = GUM_DFT(x, x_cov)
 
-        # recover signal
-        x_reconstructed, x_reconstructed_cov, sens = GUM_iDFT(
-            X, X_cov, Nx=Nx, returnC=True
-        )
+# @given(DFT_identity_input_output_lengths())
+@pytest.mark.parametrize("N", [9, 10, 11, 12, 15, 20])
+@pytest.mark.parametrize("Nx", [9, 10, 11, 12, 15, 20])
+def test_DFT_identity(N, Nx):
 
-        # check signal and covariance in case of reconstruction to identity
-        if N == Nx:
-            assert np.allclose(x, x_reconstructed)
-            assert np.allclose(x_cov, x_reconstructed_cov)
+    x, x_cov = np.arange(N) + 2, np.eye(N)
 
-        # check against numpy implementation using the sensitivties
-        # x_reconstructed is internally calculated using numpy, so this is not tested here
-        C = np.hstack((sens["Cc"], sens["Cs"]))
-        assert np.allclose(x_reconstructed, C @ X / Nx)
+    # get spectrum
+    X, X_cov = GUM_DFT(x, x_cov)
 
-    def test_iDFT_Monte_Carlo(self):
-        pass
+    # recover signal
+    x_reconstructed, x_reconstructed_cov, sens = GUM_iDFT(X, X_cov, Nx=Nx, returnC=True)
+
+    # check signal and covariance in case of reconstruction to identity
+    if N == Nx:
+        assert np.allclose(x, x_reconstructed)
+        assert np.allclose(x_cov, x_reconstructed_cov)
+
+    # check against numpy implementation using the sensitivties
+    # x_reconstructed is internally calculated using numpy, so this is not tested here
+    C = np.hstack((sens["Cc"], sens["Cs"]))
+    assert np.allclose(x_reconstructed, C @ X / Nx)
+
+
+def test_iDFT_Monte_Carlo():
+    pass
 
 
 @pytest.mark.slow

--- a/test/test_DFT.py
+++ b/test/test_DFT.py
@@ -217,7 +217,7 @@ class TestDFT:
         C = np.hstack((sens["Cc"], sens["Cs"]))
         assert np.allclose(x_reconstructed, C @ X / Nx)
 
-    def test_iDFT_Monte_Carlo():
+    def test_iDFT_Monte_Carlo(self):
         pass
 
 

--- a/test/test_DFT.py
+++ b/test/test_DFT.py
@@ -164,13 +164,13 @@ def random_vector_and_matrix_with_matching_number_of_columns(
 @composite
 def iDFT_input_output_lengths(draw: Callable, equal_lengths: bool = False):
 
-    input_length =  draw(hst.integers(min_value=5, max_value=15))
+    input_length = draw(hst.integers(min_value=5, max_value=15))
 
     if equal_lengths:
         output_length = input_length
     else:
         output_length = draw(hst.integers(min_value=5, max_value=15))
-    
+
     return {"input_length": input_length, "output_length": output_length}
 
 
@@ -233,7 +233,7 @@ def test_iDFT_resampling_sensitivity(params):
     X, X_cov = GUM_DFT(x, x_cov)
 
     # resample signal
-    x_resampled, x_resampled_cov, sens = GUM_iDFT(X, X_cov, Nx=Nx, returnC=True)
+    x_resampled, _, sens = GUM_iDFT(X, X_cov, Nx=Nx, returnC=True)
     x_resampled_numpy = np.fft.irfft(ri2c(X), n=Nx)
 
     # check resampled signal against numpy implementation
@@ -242,8 +242,6 @@ def test_iDFT_resampling_sensitivity(params):
     # check sensitivities against numpy implementation
     C = np.hstack((sens["Cc"], sens["Cs"]))
     assert_allclose(x_resampled_numpy, C @ X / Nx, atol=1e-14)
-
-
 
 
 @pytest.mark.slow

--- a/test/test_DFT.py
+++ b/test/test_DFT.py
@@ -161,9 +161,15 @@ def random_vector_and_matrix_with_matching_number_of_columns(
 
 
 @composite
-def DFT_identity_input_output_lengths(draw: Callable):
-    input_length = draw(hst.integers(min_value=10, max_value=12))
-    output_length = draw(hst.integers(min_value=9, max_value=13))
+def iDFT_input_output_lengths(draw: Callable, equal_lengths: bool = False):
+
+    input_length =  draw(hst.integers(min_value=5, max_value=15))
+
+    if equal_lengths:
+        output_length = input_length
+    else:
+        output_length = draw(hst.integers(min_value=5, max_value=15))
+    
     return {"input_length": input_length, "output_length": output_length}
 
 

--- a/test/test_DFT.py
+++ b/test/test_DFT.py
@@ -347,3 +347,44 @@ def test__prod_against_known_result_for_vector_b():
         ),
         np.array([[0, 1, 4, 9], [0, 5, 12, 21], [0, 9, 20, 33]]),
     )
+
+
+def test_DFT_identity_even_input():
+
+    x, x_cov = np.arange(10), np.eye(10)
+
+    # get spectrum
+    X, X_cov = GUM_DFT(x, x_cov)
+
+    # recover signal
+    x_reconstructed, x_reconstructed_cov, sens = GUM_iDFT(X, X_cov, Nx=x.size, returnC=True)
+
+    # check identity of signal and covariance
+    assert np.allclose(x, x_reconstructed)
+    assert np.allclose(x_cov, x_reconstructed_cov)
+
+    # check if sensitivties match the numpy implementation
+    C = np.hstack((sens["Cc"], sens["Cs"])) / x.size
+    assert np.allclose(x_reconstructed, C@X)
+
+
+def test_DFT_identity_odd_input():
+
+    x, x_cov = np.arange(11), np.eye(11)
+
+    # get spectrum
+    X, X_cov = GUM_DFT(x, x_cov)
+
+    # recover signal
+    x_reconstructed, x_reconstructed_cov, sens = GUM_iDFT(X, X_cov, Nx=x.size, returnC=True)
+
+    # check identity of signal and covariance
+    assert np.allclose(x, x_reconstructed)
+    assert np.allclose(x_cov, x_reconstructed_cov)
+    
+    # check if sensitivties match the numpy implementation
+    C = np.hstack((sens["Cc"], sens["Cs"])) / x.size
+    assert np.allclose(x_reconstructed, C@X)
+
+def test_iDFT_Monte_Carlo():
+    pass

--- a/test/test_DFT.py
+++ b/test/test_DFT.py
@@ -192,7 +192,7 @@ class TestDFT:
         x, ux = AmpPhase2Time(A, P, UAP)
         assert_almost_equal(np.max(np.abs(testsignal - x)), 0)
 
-    #@given(DFT_identity_input_output_lengths())
+    # @given(DFT_identity_input_output_lengths())
     @pytest.mark.parametrize("N", [9, 10, 11, 12, 15, 20])
     @pytest.mark.parametrize("Nx", [9, 10, 11, 12, 15, 20])
     def test_DFT_identity(self, N, Nx):

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -19,6 +19,8 @@ from PyDynamic.misc.tools import (
     real_imag_2_complex,
     separate_real_imag_of_mc_samples,
     separate_real_imag_of_vector,
+    trimOrPad,
+    trimOrPad_ND,
 )
 from .conftest import (
     hypothesis_covariance_matrix,
@@ -335,3 +337,34 @@ def test_real_imag_2_complex_array_wrong_len(array):
         r"imaginary parts but the first one is of odd length=.*",
     ):
         real_imag_2_complex(array)
+
+
+def test_trimOrPad():
+    N = 10
+    a = np.arange(N)
+
+    assert np.all(trimOrPad(a, 8) == a[:8])
+    assert np.all(trimOrPad(a, 12) == np.r_[a, [0,0]])
+
+
+def test_trimOrPad_ND():
+    N = 10
+    a = np.arange(N)
+
+    # compare against old implementation
+    assert np.all(trimOrPad(a, 8) == trimOrPad_ND(a, 8))
+    assert np.all(trimOrPad(a, 12) == trimOrPad_ND(a, 12))
+
+    # test multidim capabilities
+    a = np.ones((3,4,5))
+    b = trimOrPad_ND(a, length=(3,4,5))
+
+    assert np.all(a == b)
+
+    # test real/imag capabilities
+    ri2c = real_imag_2_complex
+    a = np.arange(N)
+    tmp1 = ri2c(trimOrPad_ND(a, N+2, real_imag_type=True))
+    tmp2 = trimOrPad_ND(ri2c(a), N+2, real_imag_type=False)
+
+    assert np.all(tmp1 == tmp2)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -20,7 +20,6 @@ from PyDynamic.misc.tools import (
     separate_real_imag_of_mc_samples,
     separate_real_imag_of_vector,
     trimOrPad,
-    trimOrPad_ND,
 )
 from .conftest import (
     hypothesis_covariance_matrix,
@@ -344,27 +343,61 @@ def test_trimOrPad():
     a = np.arange(N)
 
     assert np.all(trimOrPad(a, 8) == a[:8])
-    assert np.all(trimOrPad(a, 12) == np.r_[a, [0,0]])
+    assert np.all(trimOrPad(a, 12) == np.r_[a, [0, 0]])
 
 
-def test_trimOrPad_ND():
+def test_trimOrPad_against_old_implementation():
+    def trimOrPad_old(
+        array: Union[List, np.ndarray], length: int, mode: str = "constant"
+    ):
+        """Trim or pad (with zeros) a vector to the desired length
+
+        Either trim or zero-pad an array to achieve the required `length`. Both actions
+        are applied to the end of the array.
+
+        Parameters
+        ----------
+        array : list, 1D np.ndarray
+            original data
+        length : int
+            length of output
+        mode : str, optional
+            handed over to np.pad, default "constant"
+
+        Returns
+        -------
+        array_modified : np.ndarray of shape (length,)
+            An either trimmed or zero-padded array
+        """
+
+        if len(array) < length:  # pad zeros to the right if too short
+            return np.pad(array, (0, length - len(array)), mode=mode)
+        else:  # trim to given length otherwise
+            return array[0:length]
+
     N = 10
     a = np.arange(N)
 
     # compare against old implementation
-    assert np.all(trimOrPad(a, 8) == trimOrPad_ND(a, 8))
-    assert np.all(trimOrPad(a, 12) == trimOrPad_ND(a, 12))
+    assert np.all(trimOrPad_old(a, 8) == trimOrPad(a, 8))
+    assert np.all(trimOrPad_old(a, 12) == trimOrPad(a, 12))
 
+
+def test_trimOrPad_ndarray():
     # test multidim capabilities
-    a = np.ones((3,4,5))
-    b = trimOrPad_ND(a, length=(3,4,5))
+    a = np.ones((3, 4, 5))
+    b = trimOrPad(a, length=(3, 4, 5))
+    c = trimOrPad(a, length=4)
 
     assert np.all(a == b)
+    assert c.shape == (4, 4, 4)
 
+
+def test_trimOrPad_realimag():
     # test real/imag capabilities
-    ri2c = real_imag_2_complex
+    N = 10
     a = np.arange(N)
-    tmp1 = ri2c(trimOrPad_ND(a, N+2, real_imag_type=True))
-    tmp2 = trimOrPad_ND(ri2c(a), N+2, real_imag_type=False)
+    tmp1 = real_imag_2_complex(trimOrPad(a, N + 2, real_imag_type=True))
+    tmp2 = trimOrPad(real_imag_2_complex(a), N + 2, real_imag_type=False)
 
     assert np.all(tmp1 == tmp2)


### PR DESCRIPTION
This PR provides a solution for #310 and with that enables DFT-identity of odd signals. Moreover, `GUM_iDFT` now fully supports the `numpy.fft.irfft(..., n=...)` argument, which means, a signal can be up- or downsampled (aka Fourier interpolation) and the formerly raised "ValueError If Nx is not smaller than dimension of UF - 2" is obsolete. 

An appropriate test is provided, which tests multiple length-combinations. 

TODO:
- add Monte Carlo test