### PR TITLE
Add elementwise multiplication of signals

### DIFF
--- a/docs/PyDynamic.uncertainty.rst
+++ b/docs/PyDynamic.uncertainty.rst
@@ -58,7 +58,7 @@ Uncertainty evaluation for interpolation
     :members:
 
 Uncertainty evaluation for multiplication
-----------------------------------------
+-----------------------------------------
 
 .. automodule:: PyDynamic.uncertainty.propagate_multiplication
     :members:

--- a/docs/PyDynamic.uncertainty.rst
+++ b/docs/PyDynamic.uncertainty.rst
@@ -56,3 +56,9 @@ Uncertainty evaluation for interpolation
 
 .. automodule:: PyDynamic.uncertainty.interpolate
     :members:
+
+Uncertainty evaluation for multiplication
+----------------------------------------
+
+.. automodule:: PyDynamic.uncertainty.propagate_multiplication
+    :members:

--- a/docs/PyDynamic.uncertainty.rst
+++ b/docs/PyDynamic.uncertainty.rst
@@ -20,6 +20,8 @@ The package consists of the following modules:
 * :mod:`PyDynamic.uncertainty.propagate_MonteCarlo`: Monte Carlo methods for digital
   filtering
 * :mod:`PyDynamic.uncertainty.interpolate`: Uncertainty evaluation for interpolation
+* :mod:`PyDynamic.uncertainty.propagate_multiplication`: Uncertainty evaluation for 
+  element-wise multiplication
 
 Uncertainty evaluation for convolutions
 ---------------------------------------

--- a/src/PyDynamic/__init__.py
+++ b/src/PyDynamic/__init__.py
@@ -71,6 +71,8 @@ __all__ = [
     "separate_real_imag_of_mc_samples",
     "separate_real_imag_of_vector",
     "complex_2_real_imag",
+    "hadamar_product",
+    "window_application",
 ]
 
 from .misc import *

--- a/src/PyDynamic/uncertainty/__init__.py
+++ b/src/PyDynamic/uncertainty/__init__.py
@@ -38,6 +38,8 @@ __all__ = [
     "wave_rec",
     "filter_design",
     "dwt_max_level",
+    "hadamar_product",
+    "window_application",
 ]
 
 from .interpolate import interp1d_unc
@@ -62,4 +64,5 @@ from .propagate_DWT import (
 )
 from .propagate_filter import FIRuncFilter, IIR_get_initial_state, IIRuncFilter
 from .propagate_MonteCarlo import MC, SMC, UMC, UMC_generic
+from .propagate_multiplication import hadamar_product, window_application
 from ..misc.noise import ARMA

--- a/src/PyDynamic/uncertainty/propagate_multiplication.py
+++ b/src/PyDynamic/uncertainty/propagate_multiplication.py
@@ -74,7 +74,6 @@ def hadamar_product(
     # deal with std-unc-only case
     U1, U2 = _ensure_cov_matrix(U1), _ensure_cov_matrix(U2)
 
-
     # simplified calculations for real-valued signals
     if real_valued:
         N = len(x1)
@@ -185,7 +184,7 @@ def window_application(A, W, cov_A=None, cov_W=None):
     .. seealso::
         :func:`numpy.multiply`
     """
-    
+
     # deal with std-unc-only case
     cov_A, cov_W = _ensure_cov_matrix(cov_A), _ensure_cov_matrix(cov_W)
 
@@ -201,7 +200,3 @@ def window_application(A, W, cov_A=None, cov_W=None):
     R, cov_R = hadamar_product(x1, U1, x2, U2)
 
     return R, cov_R
-
-
-def matrix_vector_product(A, x, Ux):
-    return 0

--- a/src/PyDynamic/uncertainty/propagate_multiplication.py
+++ b/src/PyDynamic/uncertainty/propagate_multiplication.py
@@ -25,8 +25,11 @@ def hadamar_product(
     U2: Optional[np.ndarray],
     real_valued: bool = False,
 ):
+    """Hadamar product of two signals with uncertainty propagation
 
-    By default, both input signals are assumed to represent a complex signal, in the
+    This is also known as elementwise multiplication.
+
+    By default, both input signals are assumed to represent a complex signal,
     where the real and imaginary part are concatenated into a single vector:
     [Re(x), Im(x)]
 
@@ -48,14 +51,14 @@ def hadamar_product(
         By default, both input signals are assumed to represent a complex signal,
         where the real and imaginary part are concatenated into a single vector
         [Re(x), Im(x)].
-        Alternativly, if both represent purely real signals, performance gains can be
-        achieved by using enabling this switch.
+        Alternatively, if both represent purely real signals, performance gains can be
+        achieved by enabling this switch.
 
     Returns
     -------
-    prod : np.ndarray
+    prod : np.ndarray, (2N,) or (N,)
         multiplied output signal
-    Uprod : np.ndarray
+    Uprod : np.ndarray, (2N, 2N) or (N, N)
         full 2D-covariance matrix of output prod
 
     References

--- a/src/PyDynamic/uncertainty/propagate_multiplication.py
+++ b/src/PyDynamic/uncertainty/propagate_multiplication.py
@@ -3,7 +3,7 @@
 The multiplication of signals is a common operation in signal and data
 processing.
 
-This module contains the following function:
+This module contains the following functions:
 
 * :func:`hadamar_product`: Elementwise Multiplication of two signals
 * :func:`window_application`: Application of a real-valued window to a complex signal
@@ -25,7 +25,7 @@ def hadamar_product(
     U2: Optional[np.ndarray],
     real_valued: bool = False,
 ):
-    """Hadamar product of two signals with uncertainty propagation
+    """Hadamar product of two uncorrelated signals with uncertainty propagation
 
     This is also known as elementwise multiplication.
 
@@ -63,8 +63,7 @@ def hadamar_product(
 
     References
     ----------
-    .. seealso::
-        :func:`numpy.multiply`
+    .. seealso:: :func:`np.multiply`
     """
 
     # check input lengths?
@@ -164,13 +163,13 @@ def window_application(A, W, cov_A=None, cov_W=None):
     W : np.ndarray, (N,)
         window
     cov_A : np.ndarray, (2N,2N) or (2N,)
-        - 2D-array: full 2D-covariance matrix associated with x1
-        - 1D-array: standard uncertainties associated with x1 (corresponding to uncorrelated entries of x1)
-        - None: corresponds to a fully certain signal x1, results in more efficient calculation (compared to using np.zeros(...))
+        - 2D-array: full 2D-covariance matrix associated with A
+        - 1D-array: standard uncertainties associated with A (corresponding to uncorrelated entries of A)
+        - None: corresponds to a fully certain signal A, results in more efficient calculation (compared to using np.zeros(...))
     cov_W : np.ndarray, (N, N) or (N,)
-        - 2D-array: full 2D-covariance matrix associated with x2
-        - 1D-array: standard uncertainties associated with x2 (corresponding to uncorrelated entries of x2)
-        - None: corresponds to a fully certain signal x2, results in more efficient calculation (compared to using np.zeros(...))
+        - 2D-array: full 2D-covariance matrix associated with W
+        - 1D-array: standard uncertainties associated with W (corresponding to uncorrelated entries of W)
+        - None: corresponds to a fully certain signal W, results in more efficient calculation (compared to using np.zeros(...))
 
     Returns
     -------
@@ -181,8 +180,7 @@ def window_application(A, W, cov_A=None, cov_W=None):
 
     References
     ----------
-    .. seealso::
-        :func:`numpy.multiply`
+    .. seealso:: :func:`np.multiply`
     """
 
     # deal with std-unc-only case

--- a/src/PyDynamic/uncertainty/propagate_multiplication.py
+++ b/src/PyDynamic/uncertainty/propagate_multiplication.py
@@ -15,7 +15,8 @@ import numpy as np
 from scipy.linalg import block_diag
 from typing import Optional
 
-from PyDynamic.uncertainty.propagate_convolution import _ensure_cov_matrix
+from .propagate_convolution import _ensure_cov_matrix
+from ..misc.tools import complex_2_real_imag
 
 
 def hadamar_product(
@@ -191,14 +192,10 @@ def window_application(
     cov_A, cov_W = _ensure_cov_matrix(cov_A), _ensure_cov_matrix(cov_W)
 
     # map to variables of hadamar product
-    x1 = A
-    U1 = cov_A
-    x2 = np.r_[W, np.zeros_like(W)]
+    x2 = complex_2_real_imag(W)
     if isinstance(cov_W, np.ndarray):
         U2 = block_diag(cov_W, np.zeros_like(cov_W))
     else:
         U2 = None
 
-    R, cov_R = hadamar_product(x1, U1, x2, U2)
-
-    return R, cov_R
+    return hadamar_product(A, cov_A, x2, U2)

--- a/src/PyDynamic/uncertainty/propagate_multiplication.py
+++ b/src/PyDynamic/uncertainty/propagate_multiplication.py
@@ -1,0 +1,198 @@
+"""This module assists in uncertainty propagation for multiplication tasks
+
+The multiplication of signals is a common operation in signal and data
+processing.
+
+This module contains the following function:
+
+* :func:`hadamar_product`: Elementwise Multiplication of two signals
+* :func:`window_application`: Application of a real-valued window to a complex signal
+"""
+
+__all__ = ["hadamar_product", "window_application"]
+
+import numpy as np
+from scipy.linalg import block_diag
+
+from PyDynamic.uncertainty.propagate_convolution import _ensure_cov_matrix
+
+def hadamar_product(x1, U1, x2, U2, real_valued=False):
+    """Hadamar product of two signals with uncertainty propagation, also known as
+    elementwise multiplication.
+
+    By default, both input signals are assumed to represent a complex signal, in the
+    where the real and imaginary part are concatenated into a single vector:
+    [Re(x), Im(x)]
+
+    Parameters
+    ----------
+    x1 : np.ndarray, (2N,) or (N,)
+        first input signal
+    U1 : np.ndarray, (2N, 2N), (N, N) or (2N,), (N,)
+        - 1D-array: standard uncertainties associated with x1 (corresponding to uncorrelated entries of x1)
+        - 2D-array: full 2D-covariance matrix associated with x1
+        - None: corresponds to a fully certain signal x1, results in more efficient calculation (compared to using np.zeros(...))
+    x2 : np.ndarray, (2N,) or (N,)
+        second input signal, same length as x1
+    U2 : np.ndarray, (2N, 2N), (N, N) or (2N,), (N,)
+        - 2D-array: full 2D-covariance matrix associated with x2
+        - 1D-array: standard uncertainties associated with x2 (corresponding to uncorrelated entries of x2)
+        - None: corresponds to a fully certain signal x2, results in more efficient calculation (compared to using np.zeros(...))
+    real_valued : bool, optional
+        By default, both input signals are assumed to represent a complex signal,
+        where the real and imaginary part are concatenated into a single vector
+        [Re(x), Im(x)].
+        Alternativly, if both represent purely real signals, performance gains can be
+        achieved by using enabling this switch.
+
+    Returns
+    -------
+    prod : np.ndarray
+        multiplied output signal
+    Uprod : np.ndarray
+        full 2D-covariance matrix of output prod
+
+    References
+    ----------
+    .. seealso::
+        :func:`numpy.multiply`
+    """
+
+    # check input lengths?
+    if len(x1) != len(x2):
+        raise ValueError("Inputs signals need to be equal in length.")
+
+    # deal with std-unc-only case
+    U1, U2 = _ensure_cov_matrix(U1), _ensure_cov_matrix(U2)
+
+
+    # simplified calculations for real-valued signals
+    if real_valued:
+        N = len(x1)
+
+        prod = x1 * x2
+
+        cov_prod = np.zeros((N, N))
+        if isinstance(U1, np.ndarray):
+            cov_prod += np.atleast_2d(x2).T * U1 * np.atleast_2d(x2)
+        if isinstance(U2, np.ndarray):
+            cov_prod += np.atleast_2d(x1).T * U2 * np.atleast_2d(x1)
+
+    else:
+        N = len(x1) // 2
+
+        # main calculations
+        prod = np.empty_like(x1)
+        prod[:N] = x1[:N] * x2[:N] - x1[N:] * x2[N:]
+        prod[N:] = x1[N:] * x2[:N] + x1[:N] * x2[N:]
+
+        # cov calculations
+        cov_prod = np.zeros((2 * N, 2 * N))
+        if isinstance(U1, np.ndarray):
+            x2r = np.atleast_2d(x2[:N])
+            x2i = np.atleast_2d(x2[N:])
+            U1rr = U1[:N, :N]
+            U1ri = U1[:N, N:]
+            U1ir = U1[N:, :N]
+            U1ii = U1[N:, N:]
+
+            cov_prod[:N, :N] += (
+                +x2r.T * U1rr * x2r
+                - x2r.T * U1ri * x2i
+                - x2i.T * U1ir * x2r
+                + x2i.T * U1ii * x2i
+            )
+            cov_prod[:N, N:] += (
+                +x2r.T * U1rr * x2i
+                + x2r.T * U1ri * x2r
+                - x2i.T * U1ir * x2i
+                - x2i.T * U1ii * x2r
+            )
+            cov_prod[N:, :N] = cov_prod[:N, N:].T
+            cov_prod[N:, N:] += (
+                +x2i.T * U1rr * x2i
+                + x2i.T * U1ri * x2r
+                + x2r.T * U1ir * x2i
+                + x2r.T * U1ii * x2r
+            )
+        if isinstance(U2, np.ndarray):
+            x1r = np.atleast_2d(x1[:N])
+            x1i = np.atleast_2d(x1[N:])
+            U2rr = U2[:N, :N]
+            U2ri = U2[:N, N:]
+            U2ir = U2[N:, :N]
+            U2ii = U2[N:, N:]
+
+            cov_prod[:N, :N] += (
+                +x1r.T * U2rr * x1r
+                - x1r.T * U2ri * x1i
+                - x1i.T * U2ir * x1r
+                + x1i.T * U2ii * x1i
+            )
+            cov_prod[:N, N:] += (
+                +x1r.T * U2rr * x1i
+                + x1r.T * U2ri * x1r
+                - x1i.T * U2ir * x1i
+                - x1i.T * U2ii * x1r
+            )
+            cov_prod[N:, :N] = cov_prod[:N, N:].T
+            cov_prod[N:, N:] += (
+                +x1i.T * U2rr * x1i
+                + x1i.T * U2ri * x1r
+                + x1r.T * U2ir * x1i
+                + x1r.T * U2ii * x1r
+            )
+
+    return prod, cov_prod
+
+
+def window_application(A, W, cov_A=None, cov_W=None):
+    """Application of a real window to a complex signal.
+
+    Parameters
+    ----------
+    A : np.ndarray, (2N,)
+        signal the window will be applied to
+    W : np.ndarray, (N,)
+        window
+    cov_A : np.ndarray, (2N,2N) or (2N,)
+        - 2D-array: full 2D-covariance matrix associated with x1
+        - 1D-array: standard uncertainties associated with x1 (corresponding to uncorrelated entries of x1)
+        - None: corresponds to a fully certain signal x1, results in more efficient calculation (compared to using np.zeros(...))
+    cov_W : np.ndarray, (N, N) or (N,)
+        - 2D-array: full 2D-covariance matrix associated with x2
+        - 1D-array: standard uncertainties associated with x2 (corresponding to uncorrelated entries of x2)
+        - None: corresponds to a fully certain signal x2, results in more efficient calculation (compared to using np.zeros(...))
+
+    Returns
+    -------
+    y : np.ndarray
+        signal with window applied
+    Uy : np.ndarray
+        full 2D-covariance matrix of windowed signal
+
+    References
+    ----------
+    .. seealso::
+        :func:`numpy.multiply`
+    """
+    
+    # deal with std-unc-only case
+    cov_A, cov_W = _ensure_cov_matrix(cov_A), _ensure_cov_matrix(cov_W)
+
+    # map to variables of hadamar product
+    x1 = A
+    U1 = cov_A
+    x2 = np.r_[W, np.zeros_like(W)]
+    if isinstance(cov_W, np.ndarray):
+        U2 = block_diag(cov_W, np.zeros_like(cov_W))
+    else:
+        U2 = None
+
+    R, cov_R = hadamar_product(x1, U1, x2, U2)
+
+    return R, cov_R
+
+
+def matrix_vector_product(A, x, Ux):
+    return 0

--- a/src/PyDynamic/uncertainty/propagate_multiplication.py
+++ b/src/PyDynamic/uncertainty/propagate_multiplication.py
@@ -66,9 +66,8 @@ def hadamar_product(
     .. seealso:: :func:`np.multiply`
     """
 
-    # check input lengths?
-    if len(x1) != len(x2):
-        raise ValueError("Inputs signals need to be equal in length.")
+    # check input lengths
+    assert len(x1) == len(x2)
 
     # deal with std-unc-only case
     U1, U2 = _ensure_cov_matrix(U1), _ensure_cov_matrix(U2)

--- a/src/PyDynamic/uncertainty/propagate_multiplication.py
+++ b/src/PyDynamic/uncertainty/propagate_multiplication.py
@@ -13,12 +13,18 @@ __all__ = ["hadamar_product", "window_application"]
 
 import numpy as np
 from scipy.linalg import block_diag
+from typing import Optional
 
 from PyDynamic.uncertainty.propagate_convolution import _ensure_cov_matrix
 
-def hadamar_product(x1, U1, x2, U2, real_valued=False):
-    """Hadamar product of two signals with uncertainty propagation, also known as
-    elementwise multiplication.
+
+def hadamar_product(
+    x1: np.ndarray,
+    U1: Optional[np.ndarray],
+    x2: np.ndarray,
+    U2: Optional[np.ndarray],
+    real_valued: bool = False,
+):
 
     By default, both input signals are assumed to represent a complex signal, in the
     where the real and imaginary part are concatenated into a single vector:

--- a/src/PyDynamic/uncertainty/propagate_multiplication.py
+++ b/src/PyDynamic/uncertainty/propagate_multiplication.py
@@ -152,8 +152,13 @@ def hadamar_product(
     return prod, cov_prod
 
 
-def window_application(A, W, cov_A=None, cov_W=None):
-    """Application of a real window to a complex signal.
+def window_application(
+    A: np.ndarray,
+    W: np.ndarray,
+    cov_A: Optional[np.ndarray] = None,
+    cov_W: Optional[np.ndarray] = None,
+):
+    """Application of a real window to a complex signal
 
     Parameters
     ----------

--- a/test/test_lsfir/test_LSFIR.py
+++ b/test/test_lsfir/test_LSFIR.py
@@ -48,6 +48,7 @@ def simulated_measurement_input_and_output(
                 "test_LSFIR_x.npz",
             ),
         )["x"],
+        atol=1e2*np.finfo(np.float64).eps,
     )
     y = dsp.lfilter(digital_filter["b"], digital_filter["a"], x)
     noise = 1e-3

--- a/test/test_multiplication.py
+++ b/test/test_multiplication.py
@@ -115,8 +115,8 @@ def test_hadamar(inputs):
     assert len(y_slow) == len(Uy_slow)
 
     # compare results
-    assert_allclose(y, y_slow, atol=20*np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_slow, atol=20*np.finfo(np.float64).eps)
+    assert_allclose(y, y_slow, atol=1e2*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_slow, atol=1e2*np.finfo(np.float64).eps)
 
 
 @given(two_x_and_Ux_of_same_length(reduced_set=True))
@@ -133,8 +133,8 @@ def test_hadamar_real_valued(inputs):
     assert len(y) == len(y_slow)
     assert len(y_slow) == len(Uy_slow)
 
-    assert_allclose(y, y_slow, atol=20*np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_slow, atol=20*np.finfo(np.float64).eps)
+    assert_allclose(y, y_slow, atol=1e2*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_slow, atol=1e2*np.finfo(np.float64).eps)
 
 
 @given(two_x_and_Ux_of_same_length())
@@ -161,8 +161,8 @@ def test_window_application(inputs):
     assert len(y_alt) == len(Uy_alt)
 
     # compare results
-    assert_allclose(y, y_alt, atol=20*np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_alt, atol=20*np.finfo(np.float64).eps)
+    assert_allclose(y, y_alt, atol=1e2*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_alt, atol=1e2*np.finfo(np.float64).eps)
 
 
 @given(complex_x_and_Ux_and_real_window())

--- a/test/test_multiplication.py
+++ b/test/test_multiplication.py
@@ -1,0 +1,175 @@
+"""Test PyDynamic.uncertainty.propagate_multiplication"""
+
+from typing import Callable
+
+import numpy as np
+import scipy.linalg as scl
+import pytest
+from hypothesis import given
+from hypothesis.strategies import composite
+from numpy.testing import assert_allclose
+
+from PyDynamic.misc.tools import complex_2_real_imag as c2ri
+from PyDynamic.misc.tools import real_imag_2_complex as ri2c
+from PyDynamic.uncertainty.propagate_multiplication import (
+    hadamar_product,
+    window_application,
+)
+from .test_propagate_convolution import x_and_Ux
+
+from .conftest import hypothesis_dimension
+
+
+def hadamar_product_slow_reference(x1, U1, x2, U2, real_valued=False):
+    """
+    reference implementation to compare against in tests
+
+    constructs the full sensitivity matrix (which is sparse), hence not efficient
+    """
+
+    #
+    if real_valued:
+        N = len(x1)
+
+        prod = x1 * x2
+        cov_prod = np.zeros((N, N))
+        C1 = np.diag(x2)
+        C2 = np.diag(x1)
+
+    else:
+        prod = c2ri(ri2c(x1) * ri2c(x2))
+        N = len(x1) // 2
+        cov_prod = np.zeros((2 * N, 2 * N))
+
+        C1 = np.block(
+            [
+                [np.diag(x2[:N]), np.diag(-x2[N:])],
+                [np.diag(x2[N:]), np.diag(x2[:N])],
+            ]
+        )
+
+        C2 = np.block(
+            [
+                [np.diag(x1[:N]), np.diag(-x1[N:])],
+                [np.diag(x1[N:]), np.diag(x1[:N])],
+            ]
+        )
+
+    # actual calculation
+    if isinstance(U1, np.ndarray):
+        cov_prod += C1 @ U1 @ C1.T
+    if isinstance(U2, np.ndarray):
+        cov_prod += C2 @ U2 @ C2.T
+    return prod, cov_prod
+
+def window_application_slow_reference(A, W, cov_A=None, cov_W=None):
+    """
+    A \in R^2N uses PyDynamic real-imag representation of a complex vector \in C^N
+    A = [A_re, A_im]
+
+    W \in R^N is real-valued window
+
+    R is result in real-imag representation, element-wise application of window (separately for real and imag values)
+    R = [A_re * W, A_im * W]
+    """
+    N = len(W)
+    R = A * np.r_[W, W]
+    cov_R = np.zeros((2 * N, 2 * N))
+
+    if isinstance(cov_A, np.ndarray):
+        # this results from applying GUM
+        CA = scl.block_diag(np.diag(W), np.diag(W))
+        cov_R = CA @ cov_A @ CA.T
+
+    if isinstance(cov_W, np.ndarray):
+        # this results from applying GUM
+        CW = np.vstack([np.diag(A[:N]), np.diag(A[N:])])
+        cov_R += CW @ cov_W @ CW.T
+
+    return R, cov_R
+
+@composite
+def two_x_and_Ux_of_same_length(draw: Callable, reduced_set=False):
+    dim = draw(hypothesis_dimension(min_value=4, max_value=6))
+    fixed_length_x_and_Ux = x_and_Ux(reduced_set=reduced_set, given_dim=2 * dim)
+    return (draw(fixed_length_x_and_Ux), draw(fixed_length_x_and_Ux))
+
+@composite
+def complex_x_and_Ux_and_real_window(draw: Callable, reduced_set=False):
+    dim = draw(hypothesis_dimension(min_value=4, max_value=6))
+    complex_x_and_Ux = x_and_Ux(reduced_set=reduced_set, given_dim=2 * dim)
+    real_window = x_and_Ux(reduced_set=reduced_set, given_dim=dim)
+    return (draw(complex_x_and_Ux), draw(real_window))
+
+@given(two_x_and_Ux_of_same_length(reduced_set=True))
+def test_hadamar(inputs):
+    input_1, input_2 = inputs
+
+    # calculate the hadamar product of input1 and input2
+    y, Uy = hadamar_product(*input_1, *input_2)
+    y_slow, Uy_slow = hadamar_product_slow_reference(*input_1, *input_2)
+
+    # compare result sizes
+    assert len(y) == len(Uy)
+    assert len(y) == len(y_slow)
+    assert len(y_slow) == len(Uy_slow)
+
+    # compare results
+    assert_allclose(y, y_slow, atol=10*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_slow, atol=10*np.finfo(np.float64).eps)
+
+
+@given(two_x_and_Ux_of_same_length(reduced_set=True))
+@pytest.mark.slow
+def test_hadamar_real_valued(inputs):
+    input_1, input_2 = inputs
+
+    # calculate the convolution of x1 and x2
+    y, Uy = hadamar_product(*input_1, *input_2, real_valued=True)
+    y_slow, Uy_slow = hadamar_product_slow_reference(*input_1, *input_2, real_valued=True)
+
+    # compare results
+    assert len(y) == len(Uy)
+    assert len(y) == len(y_slow)
+    assert len(y_slow) == len(Uy_slow)
+
+    assert_allclose(y, y_slow, atol=10*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_slow, atol=10*np.finfo(np.float64).eps)
+
+
+@given(two_x_and_Ux_of_same_length())
+@pytest.mark.slow
+def test_hadamar_common_call(inputs):
+    input_1, input_2 = inputs
+
+    # check common execution of convolve_unc
+    assert hadamar_product(*input_1, *input_2)
+
+
+@given(complex_x_and_Ux_and_real_window(reduced_set=True))
+def test_window_application(inputs):
+    x, Ux = inputs[0]
+    w, Uw = inputs[1]
+
+    # calculate the hadamar product of input1 and input2
+    y, Uy = window_application(x, w, Ux, Uw)
+    y_alt, Uy_alt = window_application_slow_reference(x, w, Ux, Uw)
+
+    # compare result sizes
+    assert len(y) == len(Uy)
+    assert len(y) == len(y_alt)
+    assert len(y_alt) == len(Uy_alt)
+
+    # compare results
+    assert_allclose(y, y_alt, atol=10*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_alt, atol=10*np.finfo(np.float64).eps)
+
+
+@given(complex_x_and_Ux_and_real_window())
+@pytest.mark.slow
+def test_window_application_common_call(inputs):
+    x, Ux = inputs[0]
+    w, Uw = inputs[1]
+
+    # calculate the hadamar product of input1 and input2
+    assert window_application(x, w, Ux, Uw)

--- a/test/test_multiplication.py
+++ b/test/test_multiplication.py
@@ -115,8 +115,8 @@ def test_hadamar(inputs):
     assert len(y_slow) == len(Uy_slow)
 
     # compare results
-    assert_allclose(y, y_slow, atol=10*np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_slow, atol=10*np.finfo(np.float64).eps)
+    assert_allclose(y, y_slow, atol=20*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_slow, atol=20*np.finfo(np.float64).eps)
 
 
 @given(two_x_and_Ux_of_same_length(reduced_set=True))
@@ -133,8 +133,8 @@ def test_hadamar_real_valued(inputs):
     assert len(y) == len(y_slow)
     assert len(y_slow) == len(Uy_slow)
 
-    assert_allclose(y, y_slow, atol=10*np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_slow, atol=10*np.finfo(np.float64).eps)
+    assert_allclose(y, y_slow, atol=20*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_slow, atol=20*np.finfo(np.float64).eps)
 
 
 @given(two_x_and_Ux_of_same_length())
@@ -161,8 +161,8 @@ def test_window_application(inputs):
     assert len(y_alt) == len(Uy_alt)
 
     # compare results
-    assert_allclose(y, y_alt, atol=10*np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_alt, atol=10*np.finfo(np.float64).eps)
+    assert_allclose(y, y_alt, atol=20*np.finfo(np.float64).eps)
+    assert_allclose(Uy, Uy_alt, atol=20*np.finfo(np.float64).eps)
 
 
 @given(complex_x_and_Ux_and_real_window())

--- a/test/test_propagate_convolution.py
+++ b/test/test_propagate_convolution.py
@@ -19,9 +19,12 @@ from .conftest import (
 
 @composite
 def x_and_Ux(
-    draw: Callable, reduced_set: bool = False
+    draw: Callable, reduced_set: bool = False, given_dim = None
 ) -> Tuple[np.ndarray, np.ndarray]:
-    dim = draw(hypothesis_dimension(min_value=4, max_value=6))
+    if given_dim:
+        dim = given_dim
+    else:
+        dim = draw(hypothesis_dimension(min_value=4, max_value=6))
     x = draw(hypothesis_float_vector(length=dim, min_value=-10, max_value=10))
     if reduced_set:
         ux_strategies = hypothesis_covariance_matrix(number_of_rows=dim, max_value=1e-3)


### PR DESCRIPTION
Element-wise multiplication (Hadamar product) is a useful operation to enable applications like "windowing" and "gating" of signals in the time and frequency domain. Two new functions are introduced with this PR.

`hadamar_product` performs element-wise multiplication of two complex vectors of same length with full covariance uncertainty propagation according to the GUM. 

`window_application` applies a real-valued window to a complex-valued signal. It relies on `hadamar_product` for the calculations. 

Tests against slower implementations that use the non-optimized matrix multiplications are provided. 

Docs can be found here: https://pydynamic.readthedocs.io/en/add_hadamar_product_unc/PyDynamic.uncertainty.html#module-PyDynamic.uncertainty.propagate_multiplication