### PR TITLE
Switch to large resource class on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ executors:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
+    resource_class: large
   conda_tester:
     working_directory: ~/repo
     docker:
@@ -20,6 +21,7 @@ executors:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
+    resource_class: large
   publisher:
     working_directory: ~/repo
     docker:


### PR DESCRIPTION
We are hoping to experience less time outs. Recently loads of pipelines fail due to exceeded time restrictions.