### PR TITLE
Introduce an absolute tolerance into all assert_allclose() statements

### DIFF
--- a/requirements/dev-requirements-py310.txt
+++ b/requirements/dev-requirements-py310.txt
@@ -31,9 +31,11 @@ babel==2.14.0
     # via
     #   jupyterlab-server
     #   sphinx
+backports-tarfile==1.1.1
+    # via jaraco-context
 beautifulsoup4==4.12.3
     # via nbconvert
-black[jupyter]==24.3.0
+black[jupyter]==24.4.2
     # via pydynamic
 bleach==6.1.0
     # via nbconvert
@@ -65,11 +67,11 @@ colorama==0.4.6
     #   twine
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.0
+contourpy==1.2.1
     # via
     #   -c requirements/requirements-py310.txt
     #   matplotlib
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via pytest-cov
 cryptography==42.0.5
     # via secretstorage
@@ -94,7 +96,7 @@ docutils==0.20.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   anyio
     #   hypothesis
@@ -104,11 +106,11 @@ executing==2.0.1
     # via stack-data
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.3
+filelock==3.14.0
     # via
     #   tox
     #   virtualenv
-fonttools==4.50.0
+fonttools==4.51.0
     # via
     #   -c requirements/requirements-py310.txt
     #   matplotlib
@@ -128,9 +130,9 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via jupyterlab
-hypothesis==6.100.0
+hypothesis==6.100.2
     # via pydynamic
-idna==3.6
+idna==3.7
     # via
     #   anyio
     #   httpx
@@ -150,7 +152,7 @@ ipykernel==6.29.4
     # via
     #   jupyterlab
     #   pydynamic
-ipython==8.23.0
+ipython==8.24.0
     # via
     #   black
     #   ipykernel
@@ -159,9 +161,9 @@ isoduration==20.11.0
     # via jsonschema
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==4.3.0
+jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.0
+jaraco-functools==4.0.1
     # via keyring
 jedi==0.19.1
     # via ipython
@@ -178,11 +180,11 @@ jinja2==3.1.3
     #   nbconvert
     #   nbsphinx
     #   sphinx
-json5==0.9.24
+json5==0.9.25
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
-jsonschema[format-nongpl]==4.21.1
+jsonschema[format-nongpl]==4.22.0
     # via
     #   jupyter-events
     #   jupyterlab-server
@@ -205,9 +207,9 @@ jupyter-core==5.7.2
     #   nbformat
 jupyter-events==0.10.0
     # via jupyter-server
-jupyter-lsp==2.2.4
+jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.13.0
+jupyter-server==2.14.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -216,15 +218,15 @@ jupyter-server==2.13.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.1.5
+jupyterlab==4.1.8
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.25.4
+jupyterlab-server==2.27.1
     # via
     #   jupyterlab
     #   notebook
-keyring==25.0.0
+keyring==25.2.0
     # via twine
 kiwisolver==1.4.5
     # via
@@ -238,11 +240,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.8.3
+matplotlib==3.8.4
     # via
     #   -c requirements/requirements-py310.txt
     #   pydynamic
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -262,15 +264,15 @@ mpmath==1.3.0
     #   sympy
 mypy-extensions==1.0.0
     # via black
-myst-parser==2.0.0
+myst-parser==3.0.1
     # via pydynamic
 nbclient==0.10.0
     # via nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   jupyter-server
     #   nbsphinx
-nbformat==5.10.3
+nbformat==5.10.4
     # via
     #   jupyter-server
     #   nbclient
@@ -282,7 +284,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nh3==0.2.17
     # via readme-renderer
-notebook==7.1.2
+notebook==7.1.3
     # via pydynamic
 notebook-shim==0.2.4
     # via
@@ -319,31 +321,31 @@ packaging==24.0
     #   python-semantic-release
     #   sphinx
     #   tox
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   -c requirements/requirements-py310.txt
     #   pydynamic
 pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.3
+parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via black
 pexpect==4.9.0
     # via ipython
-pillow==10.2.0
+pillow==10.3.0
     # via
     #   -c requirements/requirements-py310.txt
     #   matplotlib
 pkginfo==1.10.0
     # via twine
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   black
     #   jupyter-core
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   pytest
     #   tox
@@ -373,7 +375,7 @@ pyparsing==3.1.2
     #   matplotlib
 pyproject-api==1.6.1
     # via tox
-pytest==8.1.1
+pytest==8.2.0
     # via
     #   pydynamic
     #   pytest-cov
@@ -399,7 +401,7 @@ pytz==2024.1
     # via
     #   -c requirements/requirements-py310.txt
     #   pandas
-pywavelets==1.5.0
+pywavelets==1.6.0
     # via
     #   -c requirements/requirements-py310.txt
     #   pydynamic
@@ -407,14 +409,14 @@ pyyaml==6.0.1
     # via
     #   jupyter-events
     #   myst-parser
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
 readme-renderer==43.0
     # via twine
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -449,7 +451,7 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.0
     # via
     #   -c requirements/requirements-py310.txt
     #   pydynamic
@@ -457,7 +459,7 @@ secretstorage==3.3.3
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-send2trash==1.8.2
+send2trash==1.8.3
     # via jupyter-server
 six==1.16.0
     # via
@@ -478,7 +480,7 @@ sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   myst-parser
     #   nbsphinx
@@ -515,7 +517,7 @@ time-series-buffer==0.1.4b0
     # via
     #   -c requirements/requirements-py310.txt
     #   pydynamic
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via nbconvert
 tokenize-rt==5.2.0
     # via black
@@ -526,6 +528,7 @@ tomli==2.0.1
     #   jupyterlab
     #   pyproject-api
     #   pytest
+    #   sphinx
     #   tox
 tomlkit==0.12.4
     # via python-semantic-release
@@ -537,11 +540,11 @@ tornado==6.4
     #   jupyterlab
     #   notebook
     #   terminado
-tox==4.14.2
+tox==4.15.0
     # via pydynamic
 tqdm==4.66.2
     # via twine
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -562,7 +565,7 @@ twine==3.8.0
     # via python-semantic-release
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   anyio
     #   async-lru
@@ -582,7 +585,7 @@ urllib3==2.2.1
     # via
     #   requests
     #   twine
-virtualenv==20.25.1
+virtualenv==20.26.1
     # via tox
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -592,7 +595,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via jupyter-server
 wheel==0.43.0
     # via python-semantic-release

--- a/requirements/dev-requirements-py311.txt
+++ b/requirements/dev-requirements-py311.txt
@@ -31,9 +31,11 @@ babel==2.14.0
     # via
     #   jupyterlab-server
     #   sphinx
+backports-tarfile==1.1.1
+    # via jaraco-context
 beautifulsoup4==4.12.3
     # via nbconvert
-black[jupyter]==24.3.0
+black[jupyter]==24.4.2
     # via pydynamic
 bleach==6.1.0
     # via nbconvert
@@ -65,11 +67,11 @@ colorama==0.4.6
     #   twine
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.0
+contourpy==1.2.1
     # via
     #   -c requirements/requirements-py311.txt
     #   matplotlib
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via pytest-cov
 cryptography==42.0.5
     # via secretstorage
@@ -98,11 +100,11 @@ executing==2.0.1
     # via stack-data
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.3
+filelock==3.14.0
     # via
     #   tox
     #   virtualenv
-fonttools==4.50.0
+fonttools==4.51.0
     # via
     #   -c requirements/requirements-py311.txt
     #   matplotlib
@@ -122,9 +124,9 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via jupyterlab
-hypothesis==6.100.0
+hypothesis==6.100.2
     # via pydynamic
-idna==3.6
+idna==3.7
     # via
     #   anyio
     #   httpx
@@ -144,7 +146,7 @@ ipykernel==6.29.4
     # via
     #   jupyterlab
     #   pydynamic
-ipython==8.23.0
+ipython==8.24.0
     # via
     #   black
     #   ipykernel
@@ -153,9 +155,9 @@ isoduration==20.11.0
     # via jsonschema
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==4.3.0
+jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.0
+jaraco-functools==4.0.1
     # via keyring
 jedi==0.19.1
     # via ipython
@@ -172,11 +174,11 @@ jinja2==3.1.3
     #   nbconvert
     #   nbsphinx
     #   sphinx
-json5==0.9.24
+json5==0.9.25
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
-jsonschema[format-nongpl]==4.21.1
+jsonschema[format-nongpl]==4.22.0
     # via
     #   jupyter-events
     #   jupyterlab-server
@@ -199,9 +201,9 @@ jupyter-core==5.7.2
     #   nbformat
 jupyter-events==0.10.0
     # via jupyter-server
-jupyter-lsp==2.2.4
+jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.13.0
+jupyter-server==2.14.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -210,15 +212,15 @@ jupyter-server==2.13.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.1.5
+jupyterlab==4.1.8
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.25.4
+jupyterlab-server==2.27.1
     # via
     #   jupyterlab
     #   notebook
-keyring==25.0.0
+keyring==25.2.0
     # via twine
 kiwisolver==1.4.5
     # via
@@ -232,11 +234,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.8.3
+matplotlib==3.8.4
     # via
     #   -c requirements/requirements-py311.txt
     #   pydynamic
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -256,15 +258,15 @@ mpmath==1.3.0
     #   sympy
 mypy-extensions==1.0.0
     # via black
-myst-parser==2.0.0
+myst-parser==3.0.1
     # via pydynamic
 nbclient==0.10.0
     # via nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   jupyter-server
     #   nbsphinx
-nbformat==5.10.3
+nbformat==5.10.4
     # via
     #   jupyter-server
     #   nbclient
@@ -276,7 +278,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nh3==0.2.17
     # via readme-renderer
-notebook==7.1.2
+notebook==7.1.3
     # via pydynamic
 notebook-shim==0.2.4
     # via
@@ -313,31 +315,31 @@ packaging==24.0
     #   python-semantic-release
     #   sphinx
     #   tox
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   -c requirements/requirements-py311.txt
     #   pydynamic
 pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.3
+parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via black
 pexpect==4.9.0
     # via ipython
-pillow==10.2.0
+pillow==10.3.0
     # via
     #   -c requirements/requirements-py311.txt
     #   matplotlib
 pkginfo==1.10.0
     # via twine
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   black
     #   jupyter-core
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   pytest
     #   tox
@@ -367,7 +369,7 @@ pyparsing==3.1.2
     #   matplotlib
 pyproject-api==1.6.1
     # via tox
-pytest==8.1.1
+pytest==8.2.0
     # via
     #   pydynamic
     #   pytest-cov
@@ -393,7 +395,7 @@ pytz==2024.1
     # via
     #   -c requirements/requirements-py311.txt
     #   pandas
-pywavelets==1.5.0
+pywavelets==1.6.0
     # via
     #   -c requirements/requirements-py311.txt
     #   pydynamic
@@ -401,14 +403,14 @@ pyyaml==6.0.1
     # via
     #   jupyter-events
     #   myst-parser
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
 readme-renderer==43.0
     # via twine
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -443,7 +445,7 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.0
     # via
     #   -c requirements/requirements-py311.txt
     #   pydynamic
@@ -451,7 +453,7 @@ secretstorage==3.3.3
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-send2trash==1.8.2
+send2trash==1.8.3
     # via jupyter-server
 six==1.16.0
     # via
@@ -472,7 +474,7 @@ sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   myst-parser
     #   nbsphinx
@@ -509,7 +511,7 @@ time-series-buffer==0.1.4b0
     # via
     #   -c requirements/requirements-py311.txt
     #   pydynamic
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via nbconvert
 tokenize-rt==5.2.0
     # via black
@@ -523,11 +525,11 @@ tornado==6.4
     #   jupyterlab
     #   notebook
     #   terminado
-tox==4.14.2
+tox==4.15.0
     # via pydynamic
 tqdm==4.66.2
     # via twine
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -548,7 +550,7 @@ twine==3.8.0
     # via python-semantic-release
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via ipython
 tzdata==2024.1
     # via
@@ -564,7 +566,7 @@ urllib3==2.2.1
     # via
     #   requests
     #   twine
-virtualenv==20.25.1
+virtualenv==20.26.1
     # via tox
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -574,7 +576,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via jupyter-server
 wheel==0.43.0
     # via python-semantic-release

--- a/requirements/dev-requirements-py38.txt
+++ b/requirements/dev-requirements-py38.txt
@@ -33,9 +33,11 @@ babel==2.14.0
     #   sphinx
 backcall==0.2.0
     # via ipython
+backports-tarfile==1.1.1
+    # via jaraco-context
 beautifulsoup4==4.12.3
     # via nbconvert
-black[jupyter]==24.3.0
+black[jupyter]==24.4.2
     # via pydynamic
 bleach==6.1.0
     # via nbconvert
@@ -71,7 +73,7 @@ contourpy==1.1.1
     # via
     #   -c requirements/requirements-py38.txt
     #   matplotlib
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via pytest-cov
 cryptography==42.0.5
     # via secretstorage
@@ -96,7 +98,7 @@ docutils==0.20.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   anyio
     #   hypothesis
@@ -105,11 +107,11 @@ executing==2.0.1
     # via stack-data
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.3
+filelock==3.14.0
     # via
     #   tox
     #   virtualenv
-fonttools==4.50.0
+fonttools==4.51.0
     # via
     #   -c requirements/requirements-py38.txt
     #   matplotlib
@@ -129,9 +131,9 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via jupyterlab
-hypothesis==6.100.0
+hypothesis==6.100.2
     # via pydynamic
-idna==3.6
+idna==3.7
     # via
     #   anyio
     #   httpx
@@ -174,9 +176,9 @@ isoduration==20.11.0
     # via jsonschema
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==4.3.0
+jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.0
+jaraco-functools==4.0.1
     # via keyring
 jedi==0.19.1
     # via ipython
@@ -193,11 +195,11 @@ jinja2==3.1.3
     #   nbconvert
     #   nbsphinx
     #   sphinx
-json5==0.9.24
+json5==0.9.25
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
-jsonschema[format-nongpl]==4.21.1
+jsonschema[format-nongpl]==4.22.0
     # via
     #   jupyter-events
     #   jupyterlab-server
@@ -220,9 +222,9 @@ jupyter-core==5.7.2
     #   nbformat
 jupyter-events==0.10.0
     # via jupyter-server
-jupyter-lsp==2.2.4
+jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.13.0
+jupyter-server==2.14.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -231,15 +233,15 @@ jupyter-server==2.13.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.1.5
+jupyterlab==4.1.8
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.25.4
+jupyterlab-server==2.27.1
     # via
     #   jupyterlab
     #   notebook
-keyring==25.0.0
+keyring==25.2.0
     # via twine
 kiwisolver==1.4.5
     # via
@@ -257,7 +259,7 @@ matplotlib==3.7.5
     # via
     #   -c requirements/requirements-py38.txt
     #   pydynamic
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -277,15 +279,15 @@ mpmath==1.3.0
     #   sympy
 mypy-extensions==1.0.0
     # via black
-myst-parser==2.0.0
+myst-parser==3.0.1
     # via pydynamic
 nbclient==0.10.0
     # via nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   jupyter-server
     #   nbsphinx
-nbformat==5.10.3
+nbformat==5.10.4
     # via
     #   jupyter-server
     #   nbclient
@@ -297,7 +299,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nh3==0.2.17
     # via readme-renderer
-notebook==7.1.2
+notebook==7.1.3
     # via pydynamic
 notebook-shim==0.2.4
     # via
@@ -340,7 +342,7 @@ pandas==2.0.3
     #   pydynamic
 pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.3
+parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via black
@@ -348,7 +350,7 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==10.2.0
+pillow==10.3.0
     # via
     #   -c requirements/requirements-py38.txt
     #   matplotlib
@@ -356,13 +358,13 @@ pkginfo==1.10.0
     # via twine
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   black
     #   jupyter-core
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   pytest
     #   tox
@@ -392,7 +394,7 @@ pyparsing==3.1.2
     #   matplotlib
 pyproject-api==1.6.1
     # via tox
-pytest==8.1.1
+pytest==8.2.0
     # via
     #   pydynamic
     #   pytest-cov
@@ -427,14 +429,14 @@ pyyaml==6.0.1
     # via
     #   jupyter-events
     #   myst-parser
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
 readme-renderer==43.0
     # via twine
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -477,7 +479,7 @@ secretstorage==3.3.3
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-send2trash==1.8.2
+send2trash==1.8.3
     # via jupyter-server
 six==1.16.0
     # via
@@ -535,7 +537,7 @@ time-series-buffer==0.1.4b0
     # via
     #   -c requirements/requirements-py38.txt
     #   pydynamic
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via nbconvert
 tokenize-rt==5.2.0
     # via black
@@ -557,11 +559,11 @@ tornado==6.4
     #   jupyterlab
     #   notebook
     #   terminado
-tox==4.14.2
+tox==4.15.0
     # via pydynamic
 tqdm==4.66.2
     # via twine
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -582,7 +584,7 @@ twine==3.8.0
     # via python-semantic-release
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   anyio
     #   async-lru
@@ -602,7 +604,7 @@ urllib3==2.2.1
     # via
     #   requests
     #   twine
-virtualenv==20.25.1
+virtualenv==20.26.1
     # via tox
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -612,7 +614,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via jupyter-server
 wheel==0.43.0
     # via python-semantic-release

--- a/requirements/dev-requirements-py39.txt
+++ b/requirements/dev-requirements-py39.txt
@@ -31,9 +31,11 @@ babel==2.14.0
     # via
     #   jupyterlab-server
     #   sphinx
+backports-tarfile==1.1.1
+    # via jaraco-context
 beautifulsoup4==4.12.3
     # via nbconvert
-black[jupyter]==24.3.0
+black[jupyter]==24.4.2
     # via pydynamic
 bleach==6.1.0
     # via nbconvert
@@ -65,11 +67,11 @@ colorama==0.4.6
     #   twine
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.0
+contourpy==1.2.1
     # via
     #   -c requirements/requirements-py39.txt
     #   matplotlib
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via pytest-cov
 cryptography==42.0.5
     # via secretstorage
@@ -94,7 +96,7 @@ docutils==0.20.1
     #   sphinx-rtd-theme
 dotty-dict==1.3.1
     # via python-semantic-release
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   anyio
     #   hypothesis
@@ -104,11 +106,11 @@ executing==2.0.1
     # via stack-data
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.3
+filelock==3.14.0
     # via
     #   tox
     #   virtualenv
-fonttools==4.50.0
+fonttools==4.51.0
     # via
     #   -c requirements/requirements-py39.txt
     #   matplotlib
@@ -128,9 +130,9 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via jupyterlab
-hypothesis==6.100.0
+hypothesis==6.100.2
     # via pydynamic
-idna==3.6
+idna==3.7
     # via
     #   anyio
     #   httpx
@@ -169,9 +171,9 @@ isoduration==20.11.0
     # via jsonschema
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==4.3.0
+jaraco-context==5.3.0
     # via keyring
-jaraco-functools==4.0.0
+jaraco-functools==4.0.1
     # via keyring
 jedi==0.19.1
     # via ipython
@@ -188,11 +190,11 @@ jinja2==3.1.3
     #   nbconvert
     #   nbsphinx
     #   sphinx
-json5==0.9.24
+json5==0.9.25
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
-jsonschema[format-nongpl]==4.21.1
+jsonschema[format-nongpl]==4.22.0
     # via
     #   jupyter-events
     #   jupyterlab-server
@@ -215,9 +217,9 @@ jupyter-core==5.7.2
     #   nbformat
 jupyter-events==0.10.0
     # via jupyter-server
-jupyter-lsp==2.2.4
+jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.13.0
+jupyter-server==2.14.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -226,15 +228,15 @@ jupyter-server==2.13.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.1.5
+jupyterlab==4.1.8
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.25.4
+jupyterlab-server==2.27.1
     # via
     #   jupyterlab
     #   notebook
-keyring==25.0.0
+keyring==25.2.0
     # via twine
 kiwisolver==1.4.5
     # via
@@ -248,11 +250,11 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.8.3
+matplotlib==3.8.4
     # via
     #   -c requirements/requirements-py39.txt
     #   pydynamic
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -272,15 +274,15 @@ mpmath==1.3.0
     #   sympy
 mypy-extensions==1.0.0
     # via black
-myst-parser==2.0.0
+myst-parser==3.0.1
     # via pydynamic
 nbclient==0.10.0
     # via nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   jupyter-server
     #   nbsphinx
-nbformat==5.10.3
+nbformat==5.10.4
     # via
     #   jupyter-server
     #   nbclient
@@ -292,7 +294,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nh3==0.2.17
     # via readme-renderer
-notebook==7.1.2
+notebook==7.1.3
     # via pydynamic
 notebook-shim==0.2.4
     # via
@@ -329,31 +331,31 @@ packaging==24.0
     #   python-semantic-release
     #   sphinx
     #   tox
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   -c requirements/requirements-py39.txt
     #   pydynamic
 pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.3
+parso==0.8.4
     # via jedi
 pathspec==0.12.1
     # via black
 pexpect==4.9.0
     # via ipython
-pillow==10.2.0
+pillow==10.3.0
     # via
     #   -c requirements/requirements-py39.txt
     #   matplotlib
 pkginfo==1.10.0
     # via twine
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   black
     #   jupyter-core
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   pytest
     #   tox
@@ -383,7 +385,7 @@ pyparsing==3.1.2
     #   matplotlib
 pyproject-api==1.6.1
     # via tox
-pytest==8.1.1
+pytest==8.2.0
     # via
     #   pydynamic
     #   pytest-cov
@@ -409,7 +411,7 @@ pytz==2024.1
     # via
     #   -c requirements/requirements-py39.txt
     #   pandas
-pywavelets==1.5.0
+pywavelets==1.6.0
     # via
     #   -c requirements/requirements-py39.txt
     #   pydynamic
@@ -417,14 +419,14 @@ pyyaml==6.0.1
     # via
     #   jupyter-events
     #   myst-parser
-pyzmq==25.1.2
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
     #   jupyter-server
 readme-renderer==43.0
     # via twine
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -459,7 +461,7 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-scipy==1.12.0
+scipy==1.13.0
     # via
     #   -c requirements/requirements-py39.txt
     #   pydynamic
@@ -467,7 +469,7 @@ secretstorage==3.3.3
     # via keyring
 semver==2.13.0
     # via python-semantic-release
-send2trash==1.8.2
+send2trash==1.8.3
     # via jupyter-server
 six==1.16.0
     # via
@@ -488,7 +490,7 @@ sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   myst-parser
     #   nbsphinx
@@ -525,7 +527,7 @@ time-series-buffer==0.1.4b0
     # via
     #   -c requirements/requirements-py39.txt
     #   pydynamic
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via nbconvert
 tokenize-rt==5.2.0
     # via black
@@ -536,6 +538,7 @@ tomli==2.0.1
     #   jupyterlab
     #   pyproject-api
     #   pytest
+    #   sphinx
     #   tox
 tomlkit==0.12.4
     # via python-semantic-release
@@ -547,11 +550,11 @@ tornado==6.4
     #   jupyterlab
     #   notebook
     #   terminado
-tox==4.14.2
+tox==4.15.0
     # via pydynamic
 tqdm==4.66.2
     # via twine
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -572,7 +575,7 @@ twine==3.8.0
     # via python-semantic-release
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   anyio
     #   async-lru
@@ -592,7 +595,7 @@ urllib3==2.2.1
     # via
     #   requests
     #   twine
-virtualenv==20.25.1
+virtualenv==20.26.1
     # via tox
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -602,7 +605,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via jupyter-server
 wheel==0.43.0
     # via python-semantic-release

--- a/requirements/requirements-py310.txt
+++ b/requirements/requirements-py310.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile --output-file=requirements/requirements-py310.txt
 #
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.50.0
+fonttools==4.51.0
     # via matplotlib
 future==1.0.0
     # via uncertainties
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.3
+matplotlib==3.8.4
     # via PyDynamic (setup.py)
 mpmath==1.3.0
     # via sympy
@@ -29,9 +29,9 @@ numpy==1.26.4
     #   time-series-buffer
 packaging==24.0
     # via matplotlib
-pandas==2.2.1
+pandas==2.2.2
     # via PyDynamic (setup.py)
-pillow==10.2.0
+pillow==10.3.0
     # via matplotlib
 pyparsing==3.1.2
     # via matplotlib
@@ -41,9 +41,9 @@ python-dateutil==2.9.0.post0
     #   pandas
 pytz==2024.1
     # via pandas
-pywavelets==1.5.0
+pywavelets==1.6.0
     # via PyDynamic (setup.py)
-scipy==1.12.0
+scipy==1.13.0
     # via PyDynamic (setup.py)
 six==1.16.0
     # via python-dateutil

--- a/requirements/requirements-py311.txt
+++ b/requirements/requirements-py311.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile --output-file=requirements/requirements-py311.txt
 #
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.50.0
+fonttools==4.51.0
     # via matplotlib
 future==1.0.0
     # via uncertainties
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.3
+matplotlib==3.8.4
     # via PyDynamic (setup.py)
 mpmath==1.3.0
     # via sympy
@@ -29,9 +29,9 @@ numpy==1.26.4
     #   time-series-buffer
 packaging==24.0
     # via matplotlib
-pandas==2.2.1
+pandas==2.2.2
     # via PyDynamic (setup.py)
-pillow==10.2.0
+pillow==10.3.0
     # via matplotlib
 pyparsing==3.1.2
     # via matplotlib
@@ -41,9 +41,9 @@ python-dateutil==2.9.0.post0
     #   pandas
 pytz==2024.1
     # via pandas
-pywavelets==1.5.0
+pywavelets==1.6.0
     # via PyDynamic (setup.py)
-scipy==1.12.0
+scipy==1.13.0
     # via PyDynamic (setup.py)
 six==1.16.0
     # via python-dateutil

--- a/requirements/requirements-py38.txt
+++ b/requirements/requirements-py38.txt
@@ -8,7 +8,7 @@ contourpy==1.1.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.50.0
+fonttools==4.51.0
     # via matplotlib
 future==1.0.0
     # via uncertainties
@@ -33,7 +33,7 @@ packaging==24.0
     # via matplotlib
 pandas==2.0.3
     # via PyDynamic (setup.py)
-pillow==10.2.0
+pillow==10.3.0
     # via matplotlib
 pyparsing==3.1.2
     # via matplotlib

--- a/requirements/requirements-py39.txt
+++ b/requirements/requirements-py39.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file=requirements/requirements-py39.txt
 #
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.50.0
+fonttools==4.51.0
     # via matplotlib
 future==1.0.0
     # via uncertainties
@@ -16,7 +16,7 @@ importlib-resources==6.4.0
     # via matplotlib
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.3
+matplotlib==3.8.4
     # via PyDynamic (setup.py)
 mpmath==1.3.0
     # via sympy
@@ -31,9 +31,9 @@ numpy==1.26.4
     #   time-series-buffer
 packaging==24.0
     # via matplotlib
-pandas==2.2.1
+pandas==2.2.2
     # via PyDynamic (setup.py)
-pillow==10.2.0
+pillow==10.3.0
     # via matplotlib
 pyparsing==3.1.2
     # via matplotlib
@@ -43,9 +43,9 @@ python-dateutil==2.9.0.post0
     #   pandas
 pytz==2024.1
     # via pandas
-pywavelets==1.5.0
+pywavelets==1.6.0
     # via PyDynamic (setup.py)
-scipy==1.12.0
+scipy==1.13.0
     # via PyDynamic (setup.py)
 six==1.16.0
     # via python-dateutil

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,7 @@ from scipy.signal import correlate
 from PyDynamic import make_semiposdef
 from PyDynamic.misc.tools import normalize_vector_or_matrix
 
+custom_atol = 1e2 * np.finfo(np.float64).eps
 
 def _check_for_ci_to_switch_off_performance_related_healthchecks():
     if _running_in_ci():

--- a/test/test_DFT.py
+++ b/test/test_DFT.py
@@ -31,6 +31,7 @@ from .conftest import (
     hypothesis_float_vector,
     hypothesis_not_negative_float_strategy,
     VectorAndCompatibleMatrix,
+    custom_atol,
 )
 
 
@@ -259,7 +260,7 @@ def test_DFT_MC(params):
     )
 
     # compare analytical and numerical result
-    assert_allclose(X, X_MC, rtol=1e-1)
+    assert_allclose(X, X_MC, rtol=1e-1, atol=custom_atol)
     assert_allclose(X_cov, X_MC_cov, atol=8e-1)
 
 
@@ -322,11 +323,11 @@ def test_iDFT_resampling_sensitivity(params):
     x_resampled_numpy = np.fft.irfft(ri2c(X), n=Nx)
 
     # check resampled signal against numpy implementation
-    assert_allclose(x_resampled_numpy, x_resampled, atol=1e-14)
+    assert_allclose(x_resampled_numpy, x_resampled, atol=custom_atol)
 
     # check sensitivities against numpy implementation
     C = np.hstack((sens["Cc"], sens["Cs"]))
-    assert_allclose(x_resampled_numpy, C @ X / Nx, atol=1e-14)
+    assert_allclose(x_resampled_numpy, C @ X / Nx, atol=custom_atol)
 
 
 @pytest.mark.slow
@@ -406,6 +407,7 @@ def test_apply_window_with_known_result(known_inputs_and_outputs_for_apply_windo
     assert_allclose(
         actual=_apply_window(**known_inputs_and_outputs_for_apply_window["inputs"]),
         desired=known_inputs_and_outputs_for_apply_window["outputs"],
+        atol=custom_atol,
     )
 
 

--- a/test/test_DFT_deconv.py
+++ b/test/test_DFT_deconv.py
@@ -14,6 +14,7 @@ from .conftest import (
     hypothesis_float_vector,
     hypothesis_nonzero_complex_vector,
     hypothesis_positive_powers_of_two,
+    custom_atol,
 )
 
 
@@ -86,11 +87,13 @@ def test_dft_deconv(
         x_deconv + x_deconv_shift_away_from_zero,
         monte_carlo_mean + x_deconv_shift_away_from_zero,
         rtol=6.8e-2,
+        atol=custom_atol,
     )
     assert_allclose(
         u_deconv + u_deconv_shift_away_from_zero,
         monte_carlo_cov + u_deconv_shift_away_from_zero,
         rtol=4.98e-1,
+        atol=custom_atol,
     )
 
 
@@ -209,4 +212,4 @@ def test_reveal_bug_in_dft_deconv_up_to_1_9(
         n_monte_carlo_runs=n_monte_carlo_runs,
         operator=complex_deconvolution_on_sets,
     )
-    assert_allclose(u_deconv + 1, y_divided_by_h_mc_cov + 1)
+    assert_allclose(u_deconv + 1, y_divided_by_h_mc_cov + 1, atol=custom_atol)

--- a/test/test_interpolate.py
+++ b/test/test_interpolate.py
@@ -7,9 +7,10 @@ import pytest
 from hypothesis import assume, given
 from hypothesis.strategies import composite
 from numpy.testing import assert_allclose
+from PyDynamic.uncertainty.interpolate import interp1d_unc, make_equidistant
 from pytest import raises
 
-from PyDynamic.uncertainty.interpolate import interp1d_unc, make_equidistant
+from .conftest import custom_atol
 
 _MIN_NODES_FOR_CUBIC_SPLINE = 4
 
@@ -595,7 +596,11 @@ def test_returnc_with_extrapolation_check_c_interp1d_unc(
 
     # Check if each row of sensitivities sum to one, which should hold for the
     # Lagrangians and proves equality with one for extrapolation sensitivities.
-    assert_allclose(np.sum(C, 1), np.ones_like(interp_inputs["x_new"]))
+    assert_allclose(
+        np.sum(C, 1),
+        np.ones_like(interp_inputs["x_new"]),
+        atol=custom_atol,
+    )
 
 
 @given(

--- a/test/test_lsfir/conftest.py
+++ b/test/test_lsfir/conftest.py
@@ -8,14 +8,15 @@ import pytest
 import scipy.signal as dsp
 from hypothesis.strategies import composite
 from numpy.testing import assert_allclose, assert_almost_equal
-
 from PyDynamic.misc.SecondOrderSystem import sos_phys2filter
 from PyDynamic.misc.tools import (
     complex_2_real_imag,
     make_semiposdef,
     real_imag_2_complex,
 )
+
 from ..conftest import (
+    custom_atol,
     hypothesis_float_vector,
     scale_matrix_or_vector_to_convex_combination,
 )
@@ -101,6 +102,7 @@ def monte_carlo(
         np.load(
             os.path.join(reference_array_path, "test_LSFIR_H.npz"),
         )["H"],
+        atol=custom_atol,
     )
     uAbs = np.std(np.abs(HMC), axis=0)
     assert_allclose(
@@ -109,6 +111,7 @@ def monte_carlo(
             os.path.join(reference_array_path, "test_LSFIR_uAbs.npz"),
         )["uAbs"],
         rtol=3.5e-2,
+        atol=custom_atol,
     )
     uPhas = np.std(np.angle(HMC), axis=0)
     assert_allclose(
@@ -117,6 +120,7 @@ def monte_carlo(
             os.path.join(reference_array_path, "test_LSFIR_uPhas.npz"),
         )["uPhas"],
         rtol=4.3e-2,
+        atol=custom_atol,
     )
     UH = np.cov(np.hstack((np.real(HMC), np.imag(HMC))), rowvar=False)
     UH = make_semiposdef(UH)
@@ -145,10 +149,16 @@ def digital_filter(measurement_system, sampling_freq):
         measurement_system["S0"], measurement_system["delta"], measurement_system["f0"]
     )
     assert_almost_equal(bc, [20465611686.098896])
-    assert_allclose(ac, np.array([1.00000000e00, 4.52389342e03, 5.11640292e10]))
+    assert_allclose(
+        ac,
+        np.array([1.00000000e00, 4.52389342e03, 5.11640292e10]),
+        atol=custom_atol,
+    )
     b, a = dsp.bilinear(bc, ac, sampling_freq)
     assert_allclose(
-        b, np.array([0.019386043211510096, 0.03877208642302019, 0.019386043211510096])
+        b,
+        np.array([0.019386043211510096, 0.03877208642302019, 0.019386043211510096]),
+        atol=custom_atol,
     )
     assert_allclose(a, np.array([1.0, -1.7975690550957188, 0.9914294872108197]))
     return {"b": b, "a": a}
@@ -168,5 +178,6 @@ def complex_freq_resp(
         np.load(
             os.path.join(reference_array_path, "test_LSFIR_Hf.npz"),
         )["Hf"],
+        atol=custom_atol,
     )
     return Hf

--- a/test/test_lsfir/test_LSFIR.py
+++ b/test/test_lsfir/test_LSFIR.py
@@ -19,6 +19,7 @@ from PyDynamic.model_estimation.fit_filter import (
 from .conftest import weights
 from ..conftest import (
     hypothesis_dimension,
+    custom_atol,
 )
 
 
@@ -48,7 +49,7 @@ def simulated_measurement_input_and_output(
                 "test_LSFIR_x.npz",
             ),
         )["x"],
-        atol=1e2*np.finfo(np.float64).eps,
+        atol=custom_atol,
     )
     y = dsp.lfilter(digital_filter["b"], digital_filter["a"], x)
     noise = 1e-3
@@ -74,6 +75,7 @@ def LSFIR_filter_fit(monte_carlo, freqs, sampling_freq):
                 "test_LSFIR_bF.npz",
             ),
         )["bF"],
+        atol=custom_atol,
     )
     assert_allclose(
         UbF,
@@ -85,6 +87,7 @@ def LSFIR_filter_fit(monte_carlo, freqs, sampling_freq):
             ),
         )["UbF"],
         rtol=3e-1,
+        atol=custom_atol,
     )
     return {"bF": bF, "UbF": UbF, "N": N, "tau": tau}
 
@@ -103,6 +106,7 @@ def fir_low_pass(measurement_system, sampling_freq):
                 "test_LSFIR_blow.npz",
             ),
         )["blow"],
+        atol=custom_atol,
     )
     return {"blow": blow, "lshift": lshift}
 
@@ -119,6 +123,7 @@ def shift(simulated_measurement_input_and_output, LSFIR_filter_fit, fir_low_pass
                 "test_LSFIR_shift.npz",
             ),
         )["shift"],
+        atol=custom_atol,
     )
     return shift
 
@@ -239,6 +244,7 @@ def test_digital_deconvolution_FIR_example_figure_5(
                 "test_LSFIR_HbF.npz",
             ),
         )["HbF"],
+        atol=custom_atol,
     )
     plt.semilogy(
         freqs * 1e-3,
@@ -660,4 +666,4 @@ def test_compare_invLSFIR_to_LSFIR(monte_carlo, freqs, sampling_freq, filter_ord
         tau=filter_order // 2,
         inv=True,
     )[0]
-    assert_allclose(b_fir, b_fir_inv_lsfir)
+    assert_allclose(b_fir, b_fir_inv_lsfir, atol=custom_atol)

--- a/test/test_lsfir/test_compare_different_dtypes.py
+++ b/test/test_lsfir/test_compare_different_dtypes.py
@@ -8,6 +8,7 @@ from PyDynamic.model_estimation.fit_filter import (
 )
 from ..conftest import (
     hypothesis_dimension,
+    custom_atol,
 )
 
 
@@ -43,5 +44,5 @@ def test(monte_carlo, complex_H_with_UH, freqs, sampling_freq, filter_order):
         UH=monte_carlo["UH"],
         mc_runs=10000,
     )
-    assert_allclose(b_real_imaginary, b_complex, rtol=4e-2)
-    assert_allclose(ub_real_imaginary, ub_complex, rtol=6e-1)
+    assert_allclose(b_real_imaginary, b_complex, rtol=4e-2, atol=custom_atol)
+    assert_allclose(ub_real_imaginary, ub_complex, rtol=6e-1, atol=custom_atol)

--- a/test/test_lsfir/test_compare_inv_ls_fir_to_unc_mc_ls_fir.py
+++ b/test/test_lsfir/test_compare_inv_ls_fir_to_unc_mc_ls_fir.py
@@ -9,6 +9,7 @@ from PyDynamic.model_estimation.fit_filter import (
 )
 from ..conftest import (
     hypothesis_dimension,
+    custom_atol,
 )
 
 
@@ -40,5 +41,5 @@ def test(monte_carlo, freqs, sampling_freq, filter_order):
         UH=monte_carlo["UH"],
         mc_runs=10000,
     )
-    assert_allclose(b_fir_mc, b_fir, rtol=4e-2)
-    assert_allclose(Ub_fir_mc, Ub_fir, atol=6e-1, rtol=6e-1)
+    assert_allclose(b_fir_mc, b_fir, rtol=4e-2, atol=custom_atol)
+    assert_allclose(Ub_fir_mc, Ub_fir, rtol=6e-1, atol=6e-1)

--- a/test/test_lsfir/test_compare_inv_ls_fir_unc_to_ls_fir.py
+++ b/test/test_lsfir/test_compare_inv_ls_fir_unc_to_ls_fir.py
@@ -9,6 +9,7 @@ from PyDynamic.model_estimation.fit_filter import (
 )
 from ..conftest import (
     hypothesis_dimension,
+    custom_atol,
 )
 
 
@@ -39,5 +40,5 @@ def test(monte_carlo, freqs, sampling_freq, filter_order):
         inv=True,
         UH=monte_carlo["UH"],
     )
-    assert_allclose(b_fir_mc, b_fir)
+    assert_allclose(b_fir_mc, b_fir, atol=custom_atol)
     assert_allclose(Ub_fir_mc, Ub_fir, atol=6e-1, rtol=6e-1)

--- a/test/test_lsfir/test_compare_ls_fir_with_svd_and_with_mc.py
+++ b/test/test_lsfir/test_compare_ls_fir_with_svd_and_with_mc.py
@@ -8,6 +8,7 @@ from PyDynamic.model_estimation.fit_filter import (
 )
 from ..conftest import (
     hypothesis_dimension,
+    custom_atol,
 )
 
 
@@ -42,5 +43,5 @@ def test(monte_carlo, freqs, sampling_freq, filter_order):
         UH=monte_carlo["UH"],
         mc_runs=10000,
     )
-    assert_allclose(b_fir_mc, b_fir_svd, rtol=9e-2)
-    assert_allclose(Ub_fir_mc, Ub_fir_svd, atol=6e-1, rtol=6e-1)
+    assert_allclose(b_fir_mc, b_fir_svd, rtol=9e-2, atol=custom_atol)
+    assert_allclose(Ub_fir_mc, Ub_fir_svd, rtol=6e-1, atol=6e-1)

--- a/test/test_lsfir/test_compare_ls_fir_zero_to_none_uncertainties.py
+++ b/test/test_lsfir/test_compare_ls_fir_zero_to_none_uncertainties.py
@@ -9,6 +9,7 @@ from PyDynamic.model_estimation.fit_filter import (
 )
 from ..conftest import (
     hypothesis_dimension,
+    custom_atol,
 )
 
 
@@ -42,7 +43,7 @@ def test_compare_LSFIR_with_zero_to_None_uncertainties_with_svd_for_fitting_one_
         inv=True,
         UH=None,
     )[0]
-    assert_allclose(b_fir_svd, b_fir_none)
+    assert_allclose(b_fir_svd, b_fir_none, atol=custom_atol)
 
 
 @given(hypothesis_dimension(min_value=4, max_value=8))
@@ -76,7 +77,7 @@ def test_compare_LSFIR_with_zero_to_None_uncertainties_and_mc_for_fitting_one_ov
         inv=True,
         UH=None,
     )[0]
-    assert_allclose(b_fir_mc, b_fir_none)
+    assert_allclose(b_fir_mc, b_fir_none, atol=custom_atol)
 
 
 @given(hypothesis_dimension(min_value=4, max_value=8))
@@ -110,4 +111,4 @@ def test_compare_LSFIR_with_zero_to_None_uncertainties_and_mc_for_fitting_H_dire
         inv=False,
         UH=None,
     )[0]
-    assert_allclose(b_fir_mc, b_fir_none)
+    assert_allclose(b_fir_mc, b_fir_none, atol=custom_atol)

--- a/test/test_propagate_DWT.py
+++ b/test/test_propagate_DWT.py
@@ -5,7 +5,6 @@ Perform test for uncertainty.propagate_DWT
 import numpy as np
 import pywt
 from numpy.testing import assert_allclose
-
 from PyDynamic.uncertainty.propagate_DWT import (
     dwt,
     dwt_max_level,
@@ -15,6 +14,8 @@ from PyDynamic.uncertainty.propagate_DWT import (
     wave_dec_realtime,
     wave_rec,
 )
+
+from .conftest import custom_atol
 
 
 def test_filter_design():
@@ -57,8 +58,8 @@ def test_dwt():
             ca, cd = pywt.dwt(x, filter_name, mode="constant")
             assert ca.size == y1.size
             assert cd.size == y2.size
-            assert_allclose(ca, y1, atol=1e-15)
-            assert_allclose(cd, y2, atol=1e-15)
+            assert_allclose(ca, y1, atol=custom_atol)
+            assert_allclose(cd, y2, atol=custom_atol)
 
 
 def test_inv_dwt():
@@ -86,7 +87,7 @@ def test_inv_dwt():
 
             # compare to pywt
             r = pywt.idwt(c_approx, c_detail, filter_name, mode="constant")
-            assert_allclose(x, r)
+            assert_allclose(x, r, atol=custom_atol)
 
 
 def test_identity_single():
@@ -110,11 +111,11 @@ def test_identity_single():
             if x.size % 2 == 0:
                 assert x.size == xr.size
                 assert Ux.size == Uxr.size
-                assert_allclose(x, xr)
+                assert_allclose(x, xr, atol=custom_atol)
             else:
                 assert x.size + 1 == xr.size
                 assert Ux.size + 1 == Uxr.size
-                assert_allclose(x, xr[:-1])
+                assert_allclose(x, xr[:-1], atol=custom_atol)
 
 
 def test_max_level():
@@ -144,7 +145,7 @@ def test_wave_dec():
             # compare output in detail
             for a, b in zip(result_pywt, coeffs):
                 assert len(a) == len(b)
-                assert_allclose(a, b, atol=1e-15)
+                assert_allclose(a, b, atol=custom_atol)
 
 
 def test_decomposition_realtime():
@@ -195,12 +196,12 @@ def test_decomposition_realtime():
             # compare output in detail
             for a, b in zip(coeffs_a, coeffs_b):
                 assert len(a) == len(b)
-                assert_allclose(a, b)
+                assert_allclose(a, b, atol=custom_atol)
 
             # compare output uncertainty in detail
             for a, b in zip(Ucoeffs_a, Ucoeffs_b):
                 assert len(a) == len(b)
-                assert_allclose(a, b)
+                assert_allclose(a, b, atol=custom_atol)
 
 
 def test_wave_rec():
@@ -229,7 +230,7 @@ def test_wave_rec():
 
             # compare output of both methods
             assert len(result_pywt) == len(x)
-            assert_allclose(result_pywt, x)
+            assert_allclose(result_pywt, x, atol=custom_atol)
 
 
 def test_identity_multi():
@@ -252,5 +253,5 @@ def test_identity_multi():
             xr, Uxr = wave_rec(coeffs, Ucoeffs, lr, hr, original_length=ol)
 
             assert x.size == xr.size
-            assert_allclose(x, xr)
+            assert_allclose(x, xr, atol=custom_atol)
             assert Ux.size == Uxr.size

--- a/test/test_propagate_convolution.py
+++ b/test/test_propagate_convolution.py
@@ -14,6 +14,7 @@ from .conftest import (
     hypothesis_covariance_matrix_with_zero_correlation,
     hypothesis_dimension,
     hypothesis_float_vector,
+    custom_atol,
 )
 
 
@@ -69,7 +70,7 @@ def test_convolution(input_1, input_2, mode):
     # compare results
     assert len(y) == len(Uy)
     assert len(y) == len(y_ref)
-    assert_allclose(y + 1, y_ref + 1, rtol=2.1e-7)
+    assert_allclose(y + 1, y_ref + 1, rtol=2.1e-7, atol=custom_atol)
 
 
 @given(x_and_Ux(reduced_set=True), x_and_Ux(reduced_set=True))

--- a/test/test_propagate_filter/test_compare_legacy_firuncfilter.py
+++ b/test/test_propagate_filter/test_compare_legacy_firuncfilter.py
@@ -9,7 +9,7 @@ from PyDynamic.uncertainty.propagate_filter import (
 from scipy.linalg import toeplitz
 from scipy.signal import lfilter, lfilter_zi
 
-from ..conftest import FIRuncFilter_input
+from ..conftest import FIRuncFilter_input, custom_atol
 
 
 @given(FIRuncFilter_input())
@@ -91,7 +91,6 @@ def test(fir_unc_filter_input):
         if isinstance(
             blow, np.ndarray
         ):  # calculate low-pass filtered signal and propagate noise
-
             if isinstance(sigma2, float):
                 Bcorr = np.correlate(blow, blow, "full")  # len(Bcorr) == 2*Ntheta - 1
                 ycorr = (
@@ -103,7 +102,6 @@ def test(fir_unc_filter_input):
                 Ulow = toeplitz(ycorr)
 
             elif isinstance(sigma2, np.ndarray):
-
                 if kind == "diag":
                     # [Leeuw1994](Covariance matrix of ARMA errors in closed form)
                     # can be
@@ -137,7 +135,6 @@ def test(fir_unc_filter_input):
                     V = N.dot(SP).dot(N.T) + M.dot(S).dot(M.T)
 
                 elif kind == "corr":
-
                     # adjust the lengths sigma2 to fit blow and theta
                     # this either crops (unused) information or appends zero-information
                     # note1: this is the reason, why Ulow will have dimension
@@ -167,7 +164,6 @@ def test(fir_unc_filter_input):
                 Ulow = np.eye(Ntheta) * sigma2
 
             elif isinstance(sigma2, np.ndarray):
-
                 if kind == "diag":
                     # V needs to be extended to cover Ntheta time steps more into the
                     # past
@@ -259,7 +255,7 @@ def test(fir_unc_filter_input):
     assert_allclose(
         legacy_y,
         current_y,
-        atol=1e-15,
+        atol=custom_atol,
     )
     assert_allclose(
         legacy_Uy,

--- a/test/test_propagate_multiplication.py
+++ b/test/test_propagate_multiplication.py
@@ -17,7 +17,7 @@ from PyDynamic.uncertainty.propagate_multiplication import (
 )
 from .test_propagate_convolution import x_and_Ux
 
-from .conftest import hypothesis_dimension
+from .conftest import hypothesis_dimension, custom_atol
 
 
 def hadamar_product_slow_reference(x1, U1, x2, U2, real_valued=False):
@@ -119,8 +119,8 @@ def test_hadamar(inputs):
     assert len(y_slow) == len(Uy_slow)
 
     # compare results
-    assert_allclose(y, y_slow, atol=1e2 * np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_slow, atol=1e2 * np.finfo(np.float64).eps)
+    assert_allclose(y, y_slow, atol=custom_atol)
+    assert_allclose(Uy, Uy_slow, atol=custom_atol)
 
 
 @given(two_x_and_Ux_of_same_length(reduced_set=True))
@@ -138,8 +138,8 @@ def test_hadamar_real_valued(inputs):
     assert len(y) == len(y_slow)
     assert len(y_slow) == len(Uy_slow)
 
-    assert_allclose(y, y_slow, atol=1e2 * np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_slow, atol=1e2 * np.finfo(np.float64).eps)
+    assert_allclose(y, y_slow, atol=custom_atol)
+    assert_allclose(Uy, Uy_slow, atol=custom_atol)
 
 
 @given(two_x_and_Ux_of_same_length())
@@ -166,8 +166,8 @@ def test_window_application(inputs):
     assert len(y_alt) == len(Uy_alt)
 
     # compare results
-    assert_allclose(y, y_alt, atol=1e2 * np.finfo(np.float64).eps)
-    assert_allclose(Uy, Uy_alt, atol=1e2 * np.finfo(np.float64).eps)
+    assert_allclose(y, y_alt, atol=custom_atol)
+    assert_allclose(Uy, Uy_alt, atol=custom_atol)
 
 
 @given(complex_x_and_Ux_and_real_window())


### PR DESCRIPTION
This PR defines a variable "`custom_atol=100*machine_epsilon`" in the `conftest.py` and uses it in all assert_allclose statements, that did not already declare a (larger) absolute tolerance previously. 

Motivation: `numpy.testing.assert_allclose` uses default values of `rtol=1e-7` and `atol=0`. This is sometimes difficult to achieve if mathematically equivalent but numerically different routines are compared, especially for array entries close to zero. The proposed absolute tolerance should provide a good compromise between achievable numerical accuracy and detecting true deviation of arrays in tests. 